### PR TITLE
validate native elements on submit

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -40,7 +40,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <br>
 
           <input type="checkbox" name="food" value="donuts" checked> I like donuts<br>
-          <input type="checkbox" name="food" value="pizza"> I like pizza<br>
+          <input type="checkbox" name="food" value="pizza" required> I like pizza<br>
           <br>
 
           <input type="radio" name="color" value="red" checked>Red<br>
@@ -61,9 +61,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div class="horizontal-section">
         <form is="iron-form" id="formPost" method="post" action="/">
           <paper-input name="name" label="Name" required></paper-input>
-          <paper-input name="name" label="Duplicate name" required></paper-input>
-          <paper-input name="animal" label="Favourite animal" required></paper-input>
           <br>
+          <p>Duplicate name <input name="name" required></p>
+          <br><br>
 
           <label>Cars</label>
           <select name="cars">
@@ -75,7 +75,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           <br><br>
           <label>Browsers</label>
-          <input list="browsers" name="browsers">
+          <input list="browsers" name="browsers" required>
             <datalist id="browsers">
               <option value="Internet Explorer">
               <option value="Firefox">
@@ -83,6 +83,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               <option value="Opera">
               <option value="Safari">
             </datalist>
+          <br><br>
+
+          <label>Pick a number</label>
+          <input type="range" name="number" min="1" max="100">
 
           <br><br><br>
           <paper-button raised

--- a/iron-form.html
+++ b/iron-form.html
@@ -39,7 +39,7 @@ call the form's `submit` method.
     function submitForm() {
       document.getElementById('form').submit();
     }
-    
+
 @demo demo/index.html
 */
 
@@ -48,6 +48,12 @@ call the form's `submit` method.
     is: 'iron-form',
 
     extends: 'form',
+
+    /**
+     * Fired if the form cannot be submitted because it's invalid.
+     *
+     * @event iron-form-invalid
+     */
 
     /**
      * Fired after the form is submitted.
@@ -86,7 +92,12 @@ call the form's `submit` method.
      * Called to submit the form.
      */
     submit: function(event) {
-      if (!this._validate()) {
+      if (!this.noValidate && !this._validate()) {
+
+        // In order to trigger the native browser invalid-form UI, we need
+        // to do perform a fake form submit.
+        this._doFakeSubmitForValidation();
+        this.fire('iron-form-invalid');
         return false;
       }
 
@@ -171,9 +182,23 @@ call the form's `submit` method.
 
     _validate: function() {
       var valid = true;
+
+      // Validate all the custom elements.
       for (var el, i = 0; el = this._customElements[i], i < this._customElements.length; i++) {
-        valid = el.validate() && valid;
+        if (el.required) {
+          valid = el.validate() && valid;
+        }
       }
+
+      // Validate the form's native elements.
+      for (var el, i = 0; el = this.elements[i], i < this.elements.length; i++) {
+        // Custom elements that extend a native element will also appear in
+        // this list, but they've already been validated.
+        if (!el.hasAttribute('is') && el.willValidate && el.checkValidity) {
+          valid = el.checkValidity() && valid;
+        }
+      }
+
       return valid;
     },
 
@@ -184,6 +209,17 @@ call the form's `submit` method.
       } else {
         return el.checked;
       }
+    },
+
+    _doFakeSubmitForValidation: function() {
+      var fakeSubmit = document.createElement('input');
+      fakeSubmit.setAttribute('type', 'submit');
+      fakeSubmit.style.display = 'none';
+      this.appendChild(fakeSubmit);
+
+      fakeSubmit.click();
+
+      this.removeChild(fakeSubmit);
     }
 
   });

--- a/test/basic.html
+++ b/test/basic.html
@@ -72,6 +72,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="InvalidForm">
+    <template>
+      <form is="iron-form" action="/responds_with_json" method="post">
+        <simple-element name="zig"></simple-element>
+        <input name="foo" required>
+      </form>
+    </template>
+  </test-fixture>
+
+
   <script>
   suite('serializing', function() {
     test('serializes both custom and native elements', function() {
@@ -159,6 +169,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       server.restore();
     });
 
+    test('does not submit forms with invalid native elements', function(done) {
+      form = fixture('InvalidForm');
+      var nativeElement = form.querySelector('input');
+      var customElement = form.querySelector('simple-element');
+      customElement.value = "foo";
+
+      var submitted = false;
+      form.addEventListener('iron-form-submit', function() {
+        submitted = true;
+      });
+
+      form.addEventListener('iron-form-invalid', function() {
+        expect(submitted).to.be.equal(false);
+        expect(nativeElement.validity.valid).to.be.equal(false);
+        expect(customElement.invalid).to.be.equal(false);
+        done();
+      });
+
+      form.submit();
+      server.respond();
+    });
+
     test('can submit with method=get', function(done) {
       form = fixture('FormGet');
 
@@ -191,7 +223,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       form.addEventListener('iron-form-response', function(event) {
         expect(submitted).to.be.equal(true);
-
         var response = event.detail;
         expect(response).to.be.ok;
         expect(response).to.be.an('object');

--- a/test/simple-element.html
+++ b/test/simple-element.html
@@ -26,8 +26,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       Polymer.IronFormElementBehavior
     ],
 
+    properties: {
+      invalid: {
+        type: Boolean,
+        value: false
+      },
+
+      value: {
+        type: String
+      }
+    },
+
     validate: function() {
-      return true;
+      var valid = this.value ? this.value != '' : false;
+      this.invalid = !valid;
+      return valid;
     }
 
   });


### PR DESCRIPTION
Added a couple of things to fix https://github.com/PolymerElements/iron-form/issues/4
- forms can have a `novalidate` property, which we now support
- actually checking whether elements are required/ have `willValidate` (for native elements)
- in order to trigger the native browser UI for invalid native form elements, we have to do a fake submit (since it works by magic, and only the form knows how to display it, and it doesn't seem to expose a way for us mortals to display it. Sigh). That native UI looks like this on Chrome
![screen shot 2015-06-02 at 3 39 49 pm](https://cloud.githubusercontent.com/assets/1369170/7949846/664d24dc-0947-11e5-9e26-4eaca94fd9c2.png)

and like this on Firefox (Firefox colours more things as invalid than Chrome does):
![screen shot 2015-06-02 at 4 51 20 pm](https://cloud.githubusercontent.com/assets/1369170/7949878/af81dc6a-0947-11e5-8d76-8f0146a6480d.png)

/cc @morethanreal @cdata @justinfagnani 