### PR TITLE
stop tracking elements when they are detached

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -95,6 +95,7 @@ call the form's `submit` method.
      */
     listeners: {
       'iron-form-element-register': '_registerElement',
+      'iron-form-element-unregister': '_unregisterElement',
       'submit': '_onSubmit'
     },
 
@@ -205,6 +206,16 @@ call the form's `submit` method.
 
     _registerElement: function(e) {
       this._customElements.push(e.target);
+    },
+
+    _unregisterElement: function(e) {
+      var target = e.detail.target;
+      if (target) {
+        var index = this._customElements.indexOf(target);
+        if (index > -1) {
+          this._customElements.splice(index, 1);
+        }
+      }
     },
 
     _validate: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -55,7 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </form>
     </template>
   </test-fixture>
-  
+
   <test-fixture id="Disabled">
     <template>
       <form is="iron-form">
@@ -91,9 +91,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-
   <script>
+  suite('registration', function() {
+    var f;
+    test('elements can be registered', function() {
+      f = fixture('Basic');
+
+      assert.equal(f._customElements.length, 1);
+      assert.equal(f.elements.length, 1);
+    });
+
+    test('elements can be unregistered', function(done) {
+      f = fixture('Basic');
+      var element = f.querySelector('simple-element');
+
+      assert.equal(f._customElements.length, 1);
+      assert.equal(f.elements.length, 1);
+
+      f.removeChild(element);
+
+      setTimeout(function() {
+        assert.equal(f._customElements.length, 0);
+        assert.equal(f.elements.length, 1);
+        done();
+      }, 200);
+    });
+  });
+
   suite('serializing', function() {
+    var f;
     test('serializes both custom and native elements', function() {
       f = fixture('Basic');
 


### PR DESCRIPTION
Removes tracked elements if they are detached.

Fixes https://github.com/PolymerElements/iron-form-element-behavior/issues/5
Needs a change in `iron-form-element-behavior` to land first: https://github.com/PolymerElements/iron-form-element-behavior/pull/7