### PR TITLE
not all required elements have a validate method

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -23,6 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="../../paper-styles/demo-pages.html">
   <link rel="import" href="../iron-form.html">
+  <link rel="import" href="simple-element.html">
 </head>
 <style>
   .wide {
@@ -43,15 +44,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <input type="checkbox" name="food" value="pizza" required> I like pizza<br>
           <br>
 
-          <input type="radio" name="color" value="red" checked>Red<br>
-          <input type="radio" name="color" value="blue" checked>Blue<br>
-          <input type="radio" name="color" value="green">Green<br>
+          <p>
+            Sample custom element, not required: <br>
+            <simple-element name="custom-one"></simple-element>
+          </p>
+
+          <p>
+            Sample custom element, required: (look, styling!)<br>
+            <simple-element required name="custom-two"></simple-element><br>
+          </p>
 
           <br><br>
 
           <paper-button raised
               onclick="clickHandler(event)">Submit</paper-button>
-          <button type="submit">Native Submit</button>
         </form>
       </div>
     </div>
@@ -63,7 +69,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <paper-input name="name" label="Name" required></paper-input>
           <br>
           <p>Duplicate name <input name="name" required></p>
-          <br><br>
+
+          <input type="radio" name="color" value="red" checked>Red<br>
+          <input type="radio" name="color" value="blue" checked>Blue<br>
+          <input type="radio" name="color" value="green">Green<br>
+          <br>
 
           <label>Cars</label>
           <select name="cars">

--- a/demo/simple-element.html
+++ b/demo/simple-element.html
@@ -1,0 +1,52 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-form-element-behavior/iron-form-element-behavior.html">
+<link rel="import" href="../../iron-validatable-behavior/iron-validatable-behavior.html">
+
+<dom-module id="simple-element">
+  <style>
+  :host([invalid]) input {
+    border-color: red;
+  }
+  </style>
+  <template>
+    <input value="{{value}}" id="input">
+  </template>
+</dom-module>
+
+<script>
+
+  Polymer({
+
+    is: 'simple-element',
+
+    behaviors: [
+      Polymer.IronFormElementBehavior,
+      Polymer.IronValidatableBehavior
+    ],
+
+    listeners: {
+      'input': '_onInput'
+    },
+
+    _onInput: function() {
+      this.value = this.$.input.value;
+    },
+
+    // Overidden from Polymer.IronValidatableBehavior. Will set the `invalid`
+    // attribute automatically, which should be used for styling.
+    _getValidity: function() {
+      return this.value != '';
+    }
+
+  });
+
+</script>

--- a/iron-form.html
+++ b/iron-form.html
@@ -240,10 +240,9 @@ call the form's `submit` method.
       for (var el, i = 0; el = this._customElements[i], i < this._customElements.length; i++) {
         if (el.required && this._useValue(el)) {
           validatable = /** @type {{validate: (function() : boolean)}} */ (el);
-          // TODO(notwaldorf): IronValidatableBehavior can return undefined if
-          // a validator is not set. It probably shouldn't, but in the meantime
-          // deal with that scenario.
-          valid = !!validatable.validate() && valid;
+          // Some elements may not have correctly defined a validate method.
+          if (validatable.validate)
+            valid = !!validatable.validate() && valid;
         }
       }
 


### PR DESCRIPTION
Once https://github.com/PolymerElements/iron-form-element-behavior/pull/16 lands, form elements will automatically have a `required` attribute, but they will not necessarily have a `validate()` method unless they defined it/used the `IronValidatableBehavior`. Do not panic at this.

Also added an example of how a custom element could be used from scratch. :art: 

