### PR TITLE
validation doesn't depend on names

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,6 +37,7 @@
     "web-component-tester": "*",
     "webcomponentsjs": "^0.7.0",
     "paper-input": "PolymerElements/paper-input#^1.0.0",
+    "paper-checkbox": "PolymerElements/paper-checkbox#^1.0.0",
     "paper-button": "PolymerElements/paper-button#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0"
   }

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,11 +17,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="apple-mobile-web-app-capable" content="yes">
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-
   <link rel="import" href="../../paper-input/paper-input.html">
   <link rel="import" href="../../paper-button/paper-button.html">
   <link rel="import" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="../../paper-styles/demo-pages.html">
+  <link rel="import" href="../../paper-checkbox/paper-checkbox.html">
   <link rel="import" href="../iron-form.html">
   <link rel="import" href="simple-element.html">
 </head>
@@ -42,7 +42,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           <input type="checkbox" name="food" value="donuts" checked> I like donuts<br>
           <input type="checkbox" name="food" value="pizza" required> I like pizza<br>
-          <br>
+          <paper-checkbox required>I like cheese</paper-checkbox><br>
 
           <p>
             Sample custom element, not required: <br>

--- a/iron-form.html
+++ b/iron-form.html
@@ -238,7 +238,7 @@ call the form's `submit` method.
       // Validate all the custom elements.
       var validatable;
       for (var el, i = 0; el = this._customElements[i], i < this._customElements.length; i++) {
-        if (el.required && this._useValue(el)) {
+        if (el.required && !el.disabled) {
           validatable = /** @type {{validate: (function() : boolean)}} */ (el);
           // Some elements may not have correctly defined a validate method.
           if (validatable.validate)

--- a/test/basic.html
+++ b/test/basic.html
@@ -91,6 +91,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="FormWithRequiredElements">
+    <template>
+      <form is="iron-form" action="/responds_with_json" method="post">
+        <simple-element required></simple-element>
+        <input required>
+      </form>
+    </template>
+  </test-fixture>
+
   <script>
   suite('registration', function() {
     var f;
@@ -115,6 +124,58 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(f.elements.length, 1);
         done();
       }, 200);
+    });
+  });
+
+  suite('validation', function() {
+    test('elements are validated if they don\'t have a name', function() {
+      var f = fixture('FormWithRequiredElements');
+      assert.equal(f._customElements.length, 1);
+      assert.equal(f.elements.length, 1);
+
+      var simpleElement = f._customElements[0];
+      var input = f.elements[0];
+
+      assert.isFalse(f.validate());
+      assert.isTrue(simpleElement.invalid);
+      assert.isFalse(input.validity.valid);
+
+      simpleElement.value = 'batman';
+      input.value = 'robin';
+
+      assert.isTrue(f.validate());
+      assert.isFalse(simpleElement.invalid);
+      assert.isTrue(input.validity.valid);
+
+      // Since the elements don't have names, they don't get serialized.
+      var json = f.serialize();
+      assert.equal(Object.keys(json).length, 0);
+    });
+
+    test('elements are validated if they have a name', function() {
+      var f = fixture('FormWithRequiredElements');
+      assert.equal(f._customElements.length, 1);
+      assert.equal(f.elements.length, 1);
+
+      var simpleElement = f._customElements[0];
+      var input = f.elements[0];
+      simpleElement.name = 'zig';
+      input.name = 'zag';
+
+      assert.isFalse(f.validate());
+      assert.isTrue(simpleElement.invalid);
+      assert.isFalse(input.validity.valid);
+
+      simpleElement.value = 'batman';
+      input.value = 'robin';
+
+      assert.isTrue(f.validate());
+      assert.isFalse(simpleElement.invalid);
+      assert.isTrue(input.validity.valid);
+
+      // The elements have names, so they're serialized.
+      var json = f.serialize();
+      assert.equal(Object.keys(json).length, 2);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-form/issues/28.

I think the scenario that finally convinced me is those annoying forms with a "check here if you agree" mandatory checkbox, that probably isn't sent to the server.

I've also pre-emptively added a `paper-checkbox` to the form, assuming that PR will land in this decade :)

:ghost: 