### PR TITLE
fix _getValidity logic for custom element in demo

### DIFF
--- a/demo/simple-element.html
+++ b/demo/simple-element.html
@@ -44,7 +44,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // Overidden from Polymer.IronValidatableBehavior. Will set the `invalid`
     // attribute automatically, which should be used for styling.
     _getValidity: function() {
-      return this.value != '';
+      return !!this.value;
     }
 
   });


### PR DESCRIPTION
When submitting the form without filling in anything in the custom element,
the value of this.value for the custom element would be undefined.
Consequently, the old logic of _getValidity() returning this.value != ''
would return true. Changing this to the less strict check !!this.value
allows it to still be considered invalid when this.value is undefined.

Closes #58.