### PR TITLE
Add new example to demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -24,6 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../paper-checkbox/paper-checkbox.html">
   <link rel="import" href="../iron-form.html">
   <link rel="import" href="simple-element.html">
+  <link rel="import" href="simple-form.html">
 </head>
 <style>
   .wide {
@@ -105,6 +106,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </form>
       </div>
     </div>
+
+    <div>
+      <h4>Disabling submission until form is valid</h4>
+      <div class="horizontal-section">
+        <simple-form id="simpleForm"></simple-form>
+      </div>
+    </div>
   </div>
 
   <br><br>
@@ -120,6 +128,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     document.getElementById('formGet').addEventListener('iron-form-submit', display);
     document.getElementById('formPost').addEventListener('iron-form-submit', display);
+    document.getElementById('simpleForm').addEventListener('iron-form-submit', display);
 
     function display(event) {
       var output = document.getElementById('output');

--- a/demo/simple-form.html
+++ b/demo/simple-form.html
@@ -1,0 +1,55 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-form/iron-form.html">
+<link rel="import" href="../../paper-input/paper-input.html">
+<link rel="import" href="../../paper-button/paper-button.html">
+
+<dom-module id="simple-form">
+  <template>
+    <form is="iron-form" id="form" action="/">
+      <paper-input name="name" label="Name"
+          required auto-validate invalid="{{nameInvalid}}">
+      </paper-input>
+      <paper-input name="animal" label="Favourite animal"
+          required auto-validate invalid="{{animalInvalid}}">
+      </paper-input>
+      <paper-button raised
+          disabled="[[_computeButtonDisabled(nameInvalid, animalInvalid)]]"
+          on-tap="_submit">
+        Submit
+      </paper-button>
+    </form>
+  </template>
+</dom-module>
+
+<script>
+
+  Polymer({
+
+    is: 'simple-form',
+
+    attached: function() {
+      // Since paper-inputs only validate onBlur, and we want to always disable
+      // submission if the form isn't valid, we need to initially validate the
+      // form to start off in a correct state.
+      this.$.form.validate();
+    },
+
+    _computeButtonDisabled: function(nameInvalid, animalInvalid) {
+      return nameInvalid || animalInvalid;
+    },
+
+    _submit: function() {
+      this.$.form.submit();
+    }
+  });
+
+</script>


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-form/issues/56

Added an example where the `disabled` state of the button is bound to the validatity of the inputs in the form (so that the form can't be attempted to be submitted until it's valid).

Looks like this:
<img width="291" alt="screen shot 2015-10-05 at 12 45 09 pm" src="https://cloud.githubusercontent.com/assets/1369170/10291523/1f34d692-6b5f-11e5-86fc-bf01ffadf325.png">


