### PR TITLE
add a presubmit hook

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -40,6 +40,24 @@ call the form's `submit` method.
       document.getElementById('form').submit();
     }
 
+To customize the request sent to the server, you can listen to the `iron-form-presubmit`
+event, and modify the form's[`iron-ajax`](https://elements.polymer-project.org/elements/iron-ajax)
+object. However, If you want to not use `iron-ajax` at all, you can cancel the
+event and do your own custom submission:
+
+  Example of modifying the request, but still using the build-in form submission:
+    form.addEventListener('iron-form-presubmit', function() {
+      this.request.method = 'put';
+      this.request.params = someCustomParams;
+    });
+
+  Example of bypassing the build-in form submission:
+    form.addEventListener('iron-form-presubmit', function(event) {
+      event.preventDefault();
+      var firebase = new Firebase(form.getAttribute('action'));
+      firebase.set(form.serialize());
+    });
+
 @demo demo/index.html
 */
 
@@ -89,12 +107,26 @@ call the form's `submit` method.
         value: function() {
           return {};
         }
+      },
+
+      /**
+      * iron-ajax request object used to submit the form.
+      */
+      request: {
+        type: Object,
       }
     },
+
     /**
      * Fired if the form cannot be submitted because it's invalid.
      *
      * @event iron-form-invalid
+     */
+
+    /**
+     * Fired before the form is submitted.
+     *
+     * @event iron-form-presubmit
      */
 
     /**
@@ -122,9 +154,9 @@ call the form's `submit` method.
 
     ready: function() {
       // Object that handles the ajax form submission request.
-      this._requestBot = document.createElement('iron-ajax');
-      this._requestBot.addEventListener('response', this._handleFormResponse.bind(this));
-      this._requestBot.addEventListener('error', this._handleFormError.bind(this));
+      this.request = document.createElement('iron-ajax');
+      this.request.addEventListener('response', this._handleFormResponse.bind(this));
+      this.request.addEventListener('error', this._handleFormError.bind(this));
 
       // Holds all the custom elements registered with this form.
       this._customElements = [];
@@ -149,20 +181,24 @@ call the form's `submit` method.
       // Native forms can also index elements magically by their name (can't make
       // this up if I tried) so we need to get the correct attributes, not the
       // elements with those names.
-      this._requestBot.url = this.getAttribute('action');
-      this._requestBot.method = this.getAttribute('method');
-      this._requestBot.contentType = this.contentType;
-      this._requestBot.withCredentials = this.withCredentials;
-      this._requestBot.headers = this.headers;
+      this.request.url = this.getAttribute('action');
+      this.request.method = this.getAttribute('method');
+      this.request.contentType = this.contentType;
+      this.request.withCredentials = this.withCredentials;
+      this.request.headers = this.headers;
 
-      if (this.method.toUpperCase() == 'POST') {
-        this._requestBot.body = json;
+      if (this.method.toUpperCase() === 'POST') {
+        this.request.body = json;
       } else {
-        this._requestBot.params = json;
+        this.request.params = json;
       }
 
-      this._requestBot.generateRequest();
-      this.fire('iron-form-submit', json);
+      // Allow for a presubmit hook
+      var event = this.fire('iron-form-presubmit', {}, {cancelable: true});
+      if(!event.defaultPrevented) {
+        this.request.generateRequest();
+        this.fire('iron-form-submit', json);
+      }
     },
 
     _onSubmit: function(event) {
@@ -286,10 +322,10 @@ call the form's `submit` method.
       // Checkboxes and radio buttons should only use their value if they're
       // checked. Custom paper-checkbox and paper-radio-button elements
       // don't have a type, but they have the correct role set.
-      if (el.type == 'checkbox' ||
-          el.type == 'radio' ||
-          el.getAttribute('role') == 'checkbox' ||
-          el.getAttribute('role') == 'radio') {
+      if (el.type === 'checkbox' ||
+          el.type === 'radio' ||
+          el.getAttribute('role') === 'checkbox' ||
+          el.getAttribute('role') === 'radio') {
         return el.checked;
       }
       return true;

--- a/test/basic.html
+++ b/test/basic.html
@@ -299,6 +299,71 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       server.respond();
     });
 
+    test('can modify the request in the presubmit', function(done) {
+      form = fixture('FormGet');
+
+      var submitted = false;
+      var presubmitted = false;
+
+      form.addEventListener('iron-form-submit', function() {
+        submitted = true;
+      });
+
+      form.addEventListener('iron-form-presubmit', function() {
+        presubmitted = true;
+        this.request.params = {batman: true};
+      });
+
+      form.addEventListener('iron-form-response', function(event) {
+        expect(submitted).to.be.equal(true);
+        expect(presubmitted).to.be.equal(true);
+
+        // We have changed the json parameters
+        expect(event.detail.url).to.contain('batman=true');
+
+        var response = event.detail.response;
+        expect(response).to.be.ok;
+        expect(response).to.be.an('object');
+        expect(response.success).to.be.equal(true);
+        done();
+      });
+
+      form.submit();
+      server.respond();
+    });
+
+
+    test('can do a custom submission in the presubmit', function(done) {
+      form = fixture('FormGet');
+
+      var presubmitted = false;
+
+      // Since we are not using the normal form submission, these events should
+      // never be called.
+      var formResponseHandler = sinon.spy();
+      form.addEventListener('iron-form-response', formResponseHandler);
+      var formSubmitHandler = sinon.spy();
+      form.addEventListener('iron-form-submit', formSubmitHandler);
+
+      form.addEventListener('iron-form-presubmit', function(event) {
+        presubmitted = true;
+        event.preventDefault();
+
+        // Your custom submission logic could go here (like using Firebase).
+        // In this case, fire a custom event as a an example.
+        this.fire('custom-form-submit');
+      });
+
+      form.addEventListener('custom-form-submit', function(event) {
+        expect(presubmitted).to.be.equal(true);
+        expect(formResponseHandler.callCount).to.be.equal(0);
+        expect(formSubmitHandler.callCount).to.be.equal(0);
+        done();
+      });
+
+      form.submit();
+    });
+
     test('can submit with method=get', function(done) {
       form = fixture('FormGet');
 
@@ -309,6 +374,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       form.addEventListener('iron-form-response', function(event) {
         expect(submitted).to.be.equal(true);
+        expect(event.detail.url).to.contain('zig=zag');
 
         var response = event.detail.response;
         expect(response).to.be.ok;
@@ -331,6 +397,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       form.addEventListener('iron-form-response', function(event) {
         expect(submitted).to.be.equal(true);
+
         var response = event.detail.response;
         expect(response).to.be.ok;
         expect(response).to.be.an('object');


### PR DESCRIPTION
Fixes #19. #26, #63 , #54 :tada: 

You can do anything in this hook. You can change the request. You can cancel the event and do your own, custom, request. You can use it to mail me a block of cheese. The world is yours.