### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "webcomponentsjs": "^0.7.0",
     "paper-input": "PolymerElements/paper-input#^1.0.0",
     "paper-checkbox": "PolymerElements/paper-checkbox#^1.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,7 +19,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../paper-input/paper-input.html">
   <link rel="import" href="../../paper-button/paper-button.html">
-  <link rel="import" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="../../paper-styles/demo-pages.html">
   <link rel="import" href="../../paper-checkbox/paper-checkbox.html">
   <link rel="import" href="../../paper-dropdown-menu/paper-dropdown-menu.html">
@@ -34,7 +33,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
 </style>
 <body>
-  <div class="horizontal center-center layout">
+  <div class="horizontal-section-container">
     <div>
       <h4>method="get"</h4>
       <div class="horizontal-section">
@@ -121,9 +120,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
     </div>
   </div>
-
   <br><br>
-  <div class="layout vertical center-center">
+  <div class="horizontal-section-container">
     <div>
       <h4>Submitted form data</h4>
       <div class="horizontal-section wide">

--- a/test/basic.html
+++ b/test/basic.html
@@ -14,10 +14,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
   <link rel="import" href="../../polymer/polymer.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../iron-form.html">
   <link rel="import" href="simple-element.html">
 


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way