### PR TITLE
Fix unnamed native elements validation

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -338,7 +338,7 @@ event and do your own custom submission:
       for (var el, i = 0; el = this.elements[i], i < this.elements.length; i++) {
         // Custom elements that extend a native element will also appear in
         // this list, but they've already been validated.
-        if (!el.hasAttribute('is') && el.willValidate && el.checkValidity && el.name) {
+        if (!el.hasAttribute('is') && el.willValidate && el.checkValidity) {
           valid = el.checkValidity() && valid;
         }
       }

--- a/test/basic.html
+++ b/test/basic.html
@@ -89,10 +89,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-  <test-fixture id="FormWithRequiredElements">
+  <test-fixture id="FormWithRequiredCustomElements">
     <template>
       <form is="iron-form" action="/responds_with_json" method="post">
         <simple-element required></simple-element>
+      </form>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="FormWithRequiredElements">
+    <template>
+      <form is="iron-form" action="/responds_with_json" method="post">
         <input required>
       </form>
     </template>
@@ -137,23 +144,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   });
 
   suite('validation', function() {
-    test('elements are validated if they don\'t have a name', function() {
-      var f = fixture('FormWithRequiredElements');
+    test('custom elements are validated if they don\'t have a name', function() {
+      var f = fixture('FormWithRequiredCustomElements');
       assert.equal(f._customElements.length, 1);
-      assert.equal(f.elements.length, 1);
 
       var simpleElement = f._customElements[0];
-      var input = f.elements[0];
+      assert.isFalse(!!simpleElement.name)
 
+      // custom elements
       assert.isFalse(f.validate());
       assert.isTrue(simpleElement.invalid);
-      assert.isFalse(input.validity.valid);
 
       simpleElement.value = 'batman';
-      input.value = 'robin';
 
       assert.isTrue(f.validate());
       assert.isFalse(simpleElement.invalid);
+
+      // Since the elements don't have names, they don't get serialized.
+      var json = f.serialize();
+      assert.equal(Object.keys(json).length, 0);
+    });
+
+    test('native elements are validated if they don\'t have a name', function() {
+      var f = fixture('FormWithRequiredElements');
+      assert.equal(f.elements.length, 1);
+
+      var input = f.elements[0];
+
+      assert.isFalse(!!input.name)
+
+      assert.isFalse(f.validate());
+      assert.isFalse(input.validity.valid);
+
+      input.value = 'robin';
+
+      assert.isTrue(f.validate());
       assert.isTrue(input.validity.valid);
 
       // Since the elements don't have names, they don't get serialized.
@@ -161,32 +186,46 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(Object.keys(json).length, 0);
     });
 
-    test('elements are validated if they have a name', function() {
-      var f = fixture('FormWithRequiredElements');
+    test('custom elements are validated if they have a name', function() {
+      var f = fixture('FormWithRequiredCustomElements');
       assert.equal(f._customElements.length, 1);
-      assert.equal(f.elements.length, 1);
 
       var simpleElement = f._customElements[0];
-      var input = f.elements[0];
       simpleElement.name = 'zig';
-      input.name = 'zag';
 
       assert.isFalse(f.validate());
       assert.isTrue(simpleElement.invalid);
-      assert.isFalse(input.validity.valid);
 
       simpleElement.value = 'batman';
-      input.value = 'robin';
 
       assert.isTrue(f.validate());
       assert.isFalse(simpleElement.invalid);
-      assert.isTrue(input.validity.valid);
 
       // The elements have names, so they're serialized.
       var json = f.serialize();
-      assert.equal(Object.keys(json).length, 2);
+      assert.equal(Object.keys(json).length, 1);
     });
+
+  test('native elements are validated if they have a name', function() {
+    var f = fixture('FormWithRequiredElements');
+    assert.equal(f.elements.length, 1);
+
+    var input = f.elements[0];
+    input.name = 'zag';
+
+    assert.isFalse(f.validate());
+    assert.isFalse(input.validity.valid);
+
+    input.value = 'robin';
+
+    assert.isTrue(f.validate());
+    assert.isTrue(input.validity.valid);
+
+    // The elements have names, so they're serialized.
+    var json = f.serialize();
+    assert.equal(Object.keys(json).length, 1);
   });
+});
 
   suite('serializing', function() {
     var f;


### PR DESCRIPTION
Required native elements must be validated regardless whether or not it has name.

Fixes #48