### PR TITLE
fix native multiple select case

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -250,23 +250,23 @@ event and do your own custom submission:
     serialize: function() {
       var json = {};
 
-      function addSerializedElement(el) {
+      function addSerializedElement(name, value) {
         // If the name doesn't exist, add it. Otherwise, serialize it to
         // an array,
-        if (!json[el.name]) {
-          json[el.name] = el.value;
+        if (!json[name]) {
+          json[name] = value;
         } else {
-          if (!Array.isArray(json[el.name])) {
-            json[el.name] = [json[el.name]];
+          if (!Array.isArray(json[name])) {
+            json[name] = [json[name]];
           }
-          json[el.name].push(el.value);
+          json[name].push(value);
         }
       }
 
       // Go through all of the registered custom components.
       for (var el, i = 0; el = this._customElements[i], i < this._customElements.length; i++) {
         if (this._useValue(el)) {
-          addSerializedElement(el);
+          addSerializedElement(el.name, el.value);
         }
       }
 
@@ -280,8 +280,16 @@ event and do your own custom submission:
         if (!this._useValue(el) ||
             (el.hasAttribute('is') && json[el.name])) {
           continue;
+        } else if (el.tagName.toLowerCase() === 'select' && el.multiple) {
+          // A <select multiple> has an array of values.
+          for (var o = 0; o < el.options.length; o++) {
+            if (el.options[o].selected) {
+              addSerializedElement(el.name, el.options[o].value);
+            }
+          }
+        } else {
+          addSerializedElement(el.name, el.value);
         }
-        addSerializedElement(el);
       }
 
       return json;

--- a/test/basic.html
+++ b/test/basic.html
@@ -109,6 +109,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="NativeSelect">
+    <template>
+      <form is="iron-form">
+        <select name="numbers" multiple>
+          <option value="one" selected>one</option>
+          <option value="two">two</option>
+          <option value="three" selected>three</option>
+          <option value="four">four</option>
+        </select>
+
+        <select name="cheese">
+          <option value="yes" selected>yes</option>
+          <option value="no">no</option>
+        </select>
+      </form>
+    </template>
+  </test-fixture>
+
   <script>
   suite('registration', function() {
     var f;
@@ -230,6 +248,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(json['foo'].length, 2);
       assert.equal(json['foo'][0], 'bar1');
       assert.equal(json['foo'][1], 'bar3');
+    });
+
+    test('serializes a native select element with or without multiple selection', function() {
+      f = fixture('NativeSelect');
+
+      assert.equal(f._customElements.length, 0);
+      assert.equal(f.elements.length, 2);
+
+      var json = f.serialize();
+      assert.equal(Object.keys(json).length, 2);
+      
+      // Single selection.
+      assert.equal(json['cheese'], 'yes');
+
+      // Multiple selection.
+      assert.equal(json['numbers'].length, 2);
+      assert.equal(json['numbers'][0], 'one');
+      assert.equal(json['numbers'][1], 'three');
     });
 
     test('does not serialize disabled elements', function() {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-form/issues/80 
(the problem is that the native `<select multiple>` has as its `value` attribute the first selected element, but if you want all of them you have to do the work yourself)

For the record: I think this method needs a refactoring, and I'm working on that on a separate PR