### PR TITLE
Dropdown-menu "Cars" uses values for submit field

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -48,10 +48,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           <paper-dropdown-menu label="Cars" name="cars" required>
             <paper-menu class="dropdown-content">
-              <paper-item>Volvo</paper-item>
-              <paper-item>Saab</paper-item>
-              <paper-item>Fiat</paper-item>
-              <paper-item>Audi</paper-item>
+              <paper-item value="volvo">Volvo</paper-item>
+              <paper-item value="saab">Saab</paper-item>
+              <paper-item value="fiat">Fiat</paper-item>
+              <paper-item value="audi">Audi</paper-item>
             </paper-menu>
           </paper-dropdown-menu>
 


### PR DESCRIPTION
Using pull-request #118 of paper-dropdown-menu paper-item value
attributes are used to set the menu value. In this way the "Get" submit
and the "Post" submit are using the same set of values for the field
"cars".

![image](https://cloud.githubusercontent.com/assets/7613804/12690745/1012f198-c6e6-11e5-95b8-df47a164b2a0.png)
