### PR TITLE
fix tests because safari is the worst

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     width: 474px;
   }
 </style>
-<body>
+<body unresolved>
   <div class="horizontal-section-container">
     <div>
       <h4>method="get"</h4>

--- a/iron-form.html
+++ b/iron-form.html
@@ -63,7 +63,6 @@ event and do your own custom submission:
 
 @demo demo/index.html
 */
-
   Polymer({
 
     is: 'iron-form',
@@ -173,6 +172,36 @@ event and do your own custom submission:
       'reset': '_onReset'
     },
 
+    registered: function() {
+      // Dear reader: I apologize for what you're about to experience. You see,
+      // Safari does not respect `required` on input elements, so it never
+      // has any browser validation bubbles to show. And we have to feature
+      // detect that, since we rely on the form submission to do the right thing.
+      // See http://caniuse.com/#search=required.
+
+      // Create a fake form, with an invalid input. If it gets submitted, it's Safari.
+      var form = document.createElement('form');
+      var input = document.createElement('input');
+      input.setAttribute('required', 'true');
+      form.appendChild(input);
+
+      // If you call submit(), the form doesn't actually fire a submit event,
+      // so you can't intercept it and cancel it. The event is only fired
+      // from the magical button click submission.
+      // See http://wayback.archive.org/web/20090323062817/http://blogs.vertigosoftware.com/snyholm/archive/2006/09/27/3788.aspx.
+      var button = document.createElement('input');
+      button.setAttribute('type', 'submit');
+      form.appendChild(button);
+
+      Polymer.clientSupportsFormValidationUI = true;
+      form.addEventListener('submit', function(event) {
+        // Oh good! We don't handle `required` correctly.
+        Polymer.clientSupportsFormValidationUI = false;
+        event.preventDefault();
+      });
+      button.click();
+    },
+
     ready: function() {
       // Object that handles the ajax form submission request.
       this.request = document.createElement('iron-ajax');
@@ -192,7 +221,7 @@ event and do your own custom submission:
       if (!this.noValidate && !this.validate()) {
         // In order to trigger the native browser invalid-form UI, we need
         // to do perform a fake form submit.
-        if (!this.disableNativeValidationUi) {
+        if (Polymer.clientSupportsFormValidationUI && !this.disableNativeValidationUi) {
           this._doFakeSubmitForValidation();
         }
         this.fire('iron-form-invalid');

--- a/test/basic.html
+++ b/test/basic.html
@@ -297,7 +297,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       var json = f.serialize();
       assert.equal(Object.keys(json).length, 2);
-      
+
       // Single selection.
       assert.equal(json['cheese'], 'yes');
 


### PR DESCRIPTION
Sooooo the tests are failing because Safari doesn't respect the `required` attribute and switfly and with great pride submits an invalid form. We kind of relied on that not happening to trigger the native validation UI, so this PR fixes that.

It's fine. Everything is fine.