### PR TITLE
Fix double submission of elements

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -304,23 +304,23 @@ event and do your own custom submission:
 
       // Go through all of the registered custom components.
       for (var el, i = 0; el = this._customElements[i], i < this._customElements.length; i++) {
-        if (this._useValue(el)) {
+        // If this custom element is inside a custom element that has already
+        // registered to this form, skip it.
+        if (!this._isChildOfRegisteredParent(el) && this._useValue(el)) {
           addSerializedElement(el.name, el.value);
         }
       }
 
       // Also go through the form's native elements.
       for (var el, i = 0; el = this.elements[i], i < this.elements.length; i++) {
-        // Checkboxes and radio buttons should only use their value if they're checked.
-        // Also, custom elements that extend native elements (like an
-        // `<input is="fancy-input">`) will appear in both lists. Since they
-        // were already added as a custom element, they don't need
-        // to be re-added.
-        if (!this._useValue(el) ||
-            (el.hasAttribute('is') && json[el.name])) {
+        // If this native element is inside a custom element that has already
+        // registered to this form, skip it.
+        if (this._isChildOfRegisteredParent(el) || !this._useValue(el)) {
           continue;
-        } else if (el.tagName.toLowerCase() === 'select' && el.multiple) {
-          // A <select multiple> has an array of values.
+        }
+
+        // A <select multiple> has an array of values.
+        if (el.tagName.toLowerCase() === 'select' && el.multiple) {
           for (var o = 0; o < el.options.length; o++) {
             if (el.options[o].selected) {
               addSerializedElement(el.name, el.options[o].value);
@@ -343,7 +343,9 @@ event and do your own custom submission:
     },
 
     _registerElement: function(e) {
-      var element = e.target;
+      // Get the actual element that fired the event
+      var element = Polymer.dom(e).rootTarget;
+
       element._parentForm = this;
       this._customElements.push(element);
 
@@ -456,6 +458,27 @@ event and do your own custom submission:
 
         this.fire('iron-form-reset');
       }, 1);
+    },
+
+    /**
+     * Returns true if `node` is in the shadow DOM of a different element,
+     * that has also implemented IronFormElementBehavior and is registered
+     * to this form.
+     */
+    _isChildOfRegisteredParent: function(node) {
+      var parent = node;
+
+      // At some point going up the tree we'll find either this form or the document.
+      while (parent && parent !== document && parent != this) {
+        // Use logical parentnode, or native ShadowRoot host.
+        parent = Polymer.dom(parent).parentNode || parent.host;
+
+        // Check if the parent was registered.
+        if (parent && parent._parentForm === this) {
+          return true;
+        }
+      }
+      return false;
     }
 
   });

--- a/test/basic.html
+++ b/test/basic.html
@@ -18,6 +18,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../polymer/polymer.html">
   <link rel="import" href="../iron-form.html">
   <link rel="import" href="simple-element.html">
+  <link rel="import" href="element-with-nested-form-element.html">
+  <link rel="import" href="element-with-nested-input.html">
 
 </head>
 <body>
@@ -39,6 +41,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <simple-element name="zig" value="zig"></simple-element>
         <simple-element name="zig" value="zag"></simple-element>
         <simple-element name="zig" value="zug"></simple-element>
+      </form>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="NestedDupes">
+    <template>
+      <form is="iron-form">
+        <element-with-nested-form-element name="foo" value="bar"></element-with-nested-form-element>
+        <element-with-nested-input name="zig" value="zag"></element-with-nested-input>
       </form>
     </template>
   </test-fixture>
@@ -316,6 +327,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var json = f.serialize();
       assert.equal(Object.keys(json).length, 1);
       assert.equal(json['foo'], 'bar1');
+    });
+
+    test('nested elements are only serialized once', function() {
+      f = fixture('NestedDupes');
+
+      assert.equal(f._customElements.length, 3);
+      
+      var json = f.serialize();
+      assert.equal(Object.keys(json).length, 2);
+      assert.equal(json['foo'], 'bar');
+      assert.equal(json['zig'], 'zag');
     });
 
   });

--- a/test/element-with-nested-form-element.html
+++ b/test/element-with-nested-form-element.html
@@ -9,10 +9,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../iron-form-element-behavior/iron-form-element-behavior.html">
+<link rel="import" href="simple-element.html">
 
-<dom-module id="simple-element">
+<dom-module id="element-with-nested-form-element">
   <template>
-    <span>[[value]]</span>
+    <simple-element name$="[[name]]"></simple-element>
   </template>
 </dom-module>
 
@@ -20,24 +21,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer({
 
-    is: 'simple-element',
+    is: 'element-with-nested-form-element',
 
     behaviors: [
       Polymer.IronFormElementBehavior
-    ],
-
-    properties: {
-      invalid: {
-        type: Boolean,
-        value: false
-      }
-    },
-
-    validate: function() {
-      var valid = this.value ? this.value != '' : false;
-      this.invalid = !valid;
-      return valid;
-    }
+    ]
 
   });
 

--- a/test/element-with-nested-input.html
+++ b/test/element-with-nested-input.html
@@ -10,9 +10,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../iron-form-element-behavior/iron-form-element-behavior.html">
 
-<dom-module id="simple-element">
+<dom-module id="element-with-nested-input">
   <template>
-    <span>[[value]]</span>
+    <input name$="[[name]]">
   </template>
 </dom-module>
 
@@ -20,24 +20,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer({
 
-    is: 'simple-element',
+    is: 'element-with-nested-input',
 
     behaviors: [
       Polymer.IronFormElementBehavior
-    ],
-
-    properties: {
-      invalid: {
-        type: Boolean,
-        value: false
-      }
-    },
-
-    validate: function() {
-      var valid = this.value ? this.value != '' : false;
-      this.invalid = !valid;
-      return valid;
-    }
+    ]
 
   });
 

--- a/test/index.html
+++ b/test/index.html
@@ -18,6 +18,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'basic.html?dom=shadow'
       ]);
     </script>
-  
+
 
 </body></html>


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-autogrow-textarea/issues/33

This is part of a 3-headed hydra of PRs that is trying to fix the following problem: `iron-form` was bad at de-duping nested elements with the same `name`, and would double submit them. The problem was that if you bind the `name` attribute all the way down, and these children you're binding it to are either native elements (so the form automatically cares about them) or custom elements with the `IronFormElementBehavior`, you would submit the same value twice.

This PR cleans up the double submission code with the logic: if you are an element who's parent has also registered to this form, assume your parent is in charge of this submission.

Landing this without the other 3 means that a `paper-textarea`and and a `iron-autogrow-textarea` will be submitted twice.

Related PRs:
- https://github.com/PolymerElements/iron-autogrow-textarea/pull/74
- https://github.com/PolymerElements/paper-input/pull/342