### PR TITLE
Fix #43 - Remove check for required

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -375,7 +375,7 @@ event and do your own custom submission:
       // Validate all the custom elements.
       var validatable;
       for (var el, i = 0; el = this._customElements[i], i < this._customElements.length; i++) {
-        if (el.required && !el.disabled) {
+        if (!el.disabled) {
           validatable = /** @type {{validate: (function() : boolean)}} */ (el);
           // Some elements may not have correctly defined a validate method.
           if (validatable.validate)


### PR DESCRIPTION
When validating form elements iron-form should check all elements regardless of if they are required. Some fields might not be required but if you enter something in them which isn't valid iron-form should call the validate method on that element.