### PR TITLE
Fixes #130 - Submits PUT requests with content in body

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -239,7 +239,8 @@ event and do your own custom submission:
       this.request.withCredentials = this.withCredentials;
       this.request.headers = this.headers;
 
-      if (this.method.toUpperCase() === 'POST') {
+      var method = this.request.method.toUpperCase();
+      if (method === 'POST' || method === 'PUT') {
         this.request.body = json;
       } else {
         this.request.params = json;

--- a/test/basic.html
+++ b/test/basic.html
@@ -102,6 +102,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </form>
     </template>
   </test-fixture>
+  
+  <test-fixture id="FormPut">
+    <template>
+      <form is="iron-form" action="/responds_with_json" method="put">
+        <simple-element name="zig" value="zag"></simple-element>
+      </form>
+    </template>
+  </test-fixture>
+  
 
   <test-fixture id="InvalidForm">
     <template>
@@ -501,6 +510,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           '{"success":true}'
         ]
       );
+      
+      server.respondWith(
+        'PUT',
+        /\/responds_with_json.*/,
+        [
+          200,
+          '{"Content-Type":"application/json"}',
+          '{"success":true}'
+        ]
+      );      
 
       server.respondWith(
         'GET',
@@ -665,6 +684,46 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       form.submit();
       server.respond();
     });
+    
+    test('can submit with method=put', function(done) {
+        form = fixture('FormPut');
+
+        var submitted = false;
+        form.addEventListener('iron-form-submit', function() {
+          submitted = true;
+        });
+
+        form.addEventListener('iron-form-response', function(event) {
+          expect(submitted).to.be.equal(true);
+
+          var response = event.detail.response;
+          expect(response).to.be.ok;
+          expect(response).to.be.an('object');
+          expect(response.success).to.be.equal(true);
+          done();
+        });
+
+        form.submit();
+        server.respond();
+      });
+
+      test('can relay errors for put', function(done) {
+        form = fixture('FormPut');
+        form.action = "/responds_with_error";
+
+        form.addEventListener('iron-form-error', function(event) {
+          var error = event.detail;
+
+          expect(error).to.be.ok;
+          expect(error).to.be.an('object');
+          expect(error.error).to.be.ok;
+          done();
+        });
+
+        form.submit();
+        server.respond();
+      });    
+    
 
   });
 


### PR DESCRIPTION
This fix puts form content in the body of either a POST or PUT.  All other method types are treated the same.
Fixes #130 