### PR TITLE
Run custom validation on fields that are not required too

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -375,7 +375,7 @@ event and do your own custom submission:
       // Validate all the custom elements.
       var validatable;
       for (var el, i = 0; el = this._customElements[i], i < this._customElements.length; i++) {
-        if (el.required && !el.disabled) {
+        if (!el.disabled) {
           validatable = /** @type {{validate: (function() : boolean)}} */ (el);
           // Some elements may not have correctly defined a validate method.
           if (validatable.validate)


### PR DESCRIPTION
Custom elements should be validated even though they are not required.
The original report #95 was mistakenly seen as a duplicate of #48 (which wasn't).
The explanation give was:

> Unfortunately, that's not how native forms work (http://jsbin.com/benome/edit?html,output). Only required elements are validated by the form, regardless of their name attribute.

However, this explanation works in terms of native check that only applies to regexp, ranges, types, etc. -- it cannot possibly apply to _custom_ validator functions on _custon_ elements.

Note that without this PR, it's impossible to implement an "optional email address" or "optional phone number".
The workaround suggested:

> If you want to do validation on your element but _not_ require it in the form I think you have to do this manually with the element itself. For example, in paper-input, you could add the auto-validate and pattern attributes (and then the input will tell you when you're not entering the right thing), but the form won't care.

Is not really a solution. I cannot think of a scenario where the current behaviour makes sense, especially since it imposes a limitation that renders common use cases really difficult and kludgy.
