### PR TITLE
PUT requests should set this.request.body

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -239,7 +239,7 @@ event and do your own custom submission:
       this.request.withCredentials = this.withCredentials;
       this.request.headers = this.headers;
 
-      if (this.method.toUpperCase() === 'POST') {
+      if (this.method.toUpperCase() === 'POST' || this.method.toUpperCase() === 'PUT') {
         this.request.body = json;
       } else {
         this.request.params = json;


### PR DESCRIPTION
POST requests already set this.request.body. PUT request must do that too, since there would be no point in having a PUT request with data in the query string.
I am happy to add tests if you are all OK with this.