### PR TITLE
Fixes #142

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -306,7 +306,7 @@ event and do your own custom submission:
       for (var el, i = 0; el = this._customElements[i], i < this._customElements.length; i++) {
         // If this custom element is inside a custom element that has already
         // registered to this form, skip it.
-        if (!this._isChildOfRegisteredParent(el) && this._useValue(el)) {
+        if (!this._isChildOfRegisteredParent(el, true) && this._useValue(el)) {
           addSerializedElement(el.name, el.value);
         }
       }
@@ -315,7 +315,7 @@ event and do your own custom submission:
       for (var el, i = 0; el = this.elements[i], i < this.elements.length; i++) {
         // If this native element is inside a custom element that has already
         // registered to this form, skip it.
-        if (this._isChildOfRegisteredParent(el) || !this._useValue(el)) {
+        if (this._isChildOfRegisteredParent(el, true) || !this._useValue(el)) {
           continue;
         }
 
@@ -375,7 +375,7 @@ event and do your own custom submission:
       // Validate all the custom elements.
       var validatable;
       for (var el, i = 0; el = this._customElements[i], i < this._customElements.length; i++) {
-        if (!el.disabled) {
+        if (!this._isChildOfRegisteredParent(el, false) && !el.disabled) {
           validatable = /** @type {{validate: (function() : boolean)}} */ (el);
           // Some elements may not have correctly defined a validate method.
           if (validatable.validate)
@@ -385,6 +385,12 @@ event and do your own custom submission:
 
       // Validate the form's native elements.
       for (var el, i = 0; el = this.elements[i], i < this.elements.length; i++) {
+        // If this native element is inside a custom element that has already
+        // registered to this form, skip it.
+        if (this._isChildOfRegisteredParent(el, false)) {
+          continue;
+        }
+
         // Custom elements that extend a native element will also appear in
         // this list, but they've already been validated.
         if (!el.hasAttribute('is') && el.willValidate && el.checkValidity) {
@@ -477,9 +483,10 @@ event and do your own custom submission:
     /**
      * Returns true if `node` is in the shadow DOM of a different element,
      * that has also implemented IronFormElementBehavior and is registered
-     * to this form.
+     * to this form. The second parameter specifies if the parent must have a
+     * name to be considered.
      */
-    _isChildOfRegisteredParent: function(node) {
+    _isChildOfRegisteredParent: function(node, checkHasName) {
       var parent = node;
 
       // At some point going up the tree we'll find either this form or the document.
@@ -488,7 +495,9 @@ event and do your own custom submission:
         parent = Polymer.dom(parent).parentNode || parent.host;
 
         // Check if the parent was registered and submittable.
-        if (parent && parent.name && parent._parentForm === this) {
+        if (parent &&
+            (!checkHasName || parent.name) &&
+            parent._parentForm === this) {
           return true;
         }
       }

--- a/test/basic.html
+++ b/test/basic.html
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="simple-element.html">
   <link rel="import" href="element-with-nested-form-element.html">
   <link rel="import" href="element-with-nested-input.html">
+  <link rel="import" href="validatable-element-with-nested-elements.html">
 
 </head>
 <body>
@@ -140,6 +141,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <form is="iron-form" action="/responds_with_json" method="post">
         <input type="text" name="letters" pattern="^[a-z]$" >
+      </form>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="FormValidateNestedElements">
+    <template>
+      <form is="iron-form">
+        <validatable-element-with-nested-elements>
+          <simple-element required></simple-element>
+          <input required>
+        </validatable-element-with-nested-elements>
       </form>
     </template>
   </test-fixture>
@@ -318,7 +330,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.isFalse(f.validate());
       assert.isFalse(input.validity.valid);
     });
-});
+
+    test('nested elements are not validated', function() {
+      var f = fixture('FormValidateNestedElements');
+
+      // <validatable-element-with-nested-elements> returns true.
+      assert.isTrue(f.validate());
+
+      // The form also contains an invalid custom and native element, but those
+      // shouldn't affect the form's validity.
+      assert.equal(f._customElements.length, 2);
+      assert.equal(f.elements.length, 1);
+      assert.isFalse(f.$$('simple-element').validate());
+      assert.isFalse(f.$$('input').checkValidity());
+    });
+  });
 
   suite('serializing', function() {
     var f;

--- a/test/validatable-element-with-nested-elements.html
+++ b/test/validatable-element-with-nested-elements.html
@@ -1,0 +1,35 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-form-element-behavior/iron-form-element-behavior.html">
+
+<dom-module id="validatable-element-with-nested-elements">
+  <template>
+    <content></content>
+  </template>
+</dom-module>
+
+<script>
+
+  Polymer({
+
+    is: 'validatable-element-with-nested-elements',
+
+    behaviors: [
+      Polymer.IronFormElementBehavior
+    ],
+
+    validate: function() {
+      return true;
+    },
+
+  });
+
+</script>


### PR DESCRIPTION
Fixes #142 by excluding nested registered elements from validation. The testcase explains it clearly.

As discussed in the issue, this is done very similarly to how these elements are excluded from serialization. The difference is that we're not checking if the parent has a name to be considered (this came up during testing and I'm only 99% sure this is the correct approach).

If you'd like to see real world examples where my team needs this, I can show you the code and we can discuss this further within Google.