### PR TITLE
Fix reset blank inputs

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -459,7 +459,11 @@ event and do your own custom submission:
           } else {
             // The native input/textarea displays literal "undefined" when its
             // its value is set to undefined, so default to null instead.
-            el.value = this._customElementsInitialValues[i] || null;
+            var value = this._customElementsInitialValues[i];
+            if (value === undefined) {
+              value = null;
+            }
+            el.value = value;
 
             // In the shady DOM, the native form is all-seeing, and will
             // reset the nested inputs inside <paper-input> and <paper-textarea>.

--- a/test/basic.html
+++ b/test/basic.html
@@ -162,7 +162,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <simple-element name="zig" value="zag"></simple-element>
         <paper-input name="zig" value="zug"></paper-input>
         <paper-textarea name="zig" value="zog"></paper-textarea>
-        <paper-textarea name="empty"></paper-textarea>
+        <paper-textarea name="undef"></paper-textarea>
         <input name="foo" value="bar">
         <input type="checkbox" name="foo" value="bar1" checked>
         <input type="checkbox" name="foo" value="bar2">
@@ -531,12 +531,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       form.reset();
     });
 
-    test('form restores empty paper-textarea if no changes were made', function(done) {
+    test('form restores null-value paper-textarea if initially undefined', function(done) {
       var form = fixture('FormForResetting');
-      var paperTextarea = form.querySelector('paper-textarea[name="empty"]');
+      var paperTextarea = form.querySelector('paper-textarea[name="undef"]');
 
       form.addEventListener('iron-form-reset', function(event) {
-        // Restored initial values.
+        // Setting the native textarea's value to undefined causes it to
+        // display literal "undefined", and paper-textarea.value is indirectly
+        // bound to the textarea's value, so iron-form resets any undefined
+        // initial values to null in order to avoid this problem.
         assert.equal(paperTextarea.value, null);
         assert.equal(paperTextarea.inputElement.textarea.value, '');
         done();

--- a/test/basic.html
+++ b/test/basic.html
@@ -161,8 +161,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <form is="iron-form">
         <simple-element name="zig" value="zag"></simple-element>
         <paper-input name="zig" value="zug"></paper-input>
+        <paper-input name="blank" value=""></paper-input>
         <paper-textarea name="zig" value="zog"></paper-textarea>
         <paper-textarea name="undef"></paper-textarea>
+        <paper-textarea name="blank" value=""></paper-textarea>
+        <input name="blank" value="">
         <input name="foo" value="bar">
         <input type="checkbox" name="foo" value="bar1" checked>
         <input type="checkbox" name="foo" value="bar2">
@@ -448,47 +451,68 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Initial values.
       var customElement = form.querySelector('simple-element');
       var input = form.querySelector('input[name="foo"]');
+      var inputBlank = form.querySelector('input[name="blank"]');
       var checkbox1 = form.querySelectorAll('input[type="checkbox"]')[0];
       var checkbox2 = form.querySelectorAll('input[type="checkbox"]')[1];
-      var paperInput = form.querySelector('paper-input');
-      var paperTextarea = form.querySelector('paper-textarea');
+      var paperInput = form.querySelector('paper-input[name="zig"]');
+      var paperInputBlank = form.querySelector('paper-input[name="blank"]');
+      var paperTextarea = form.querySelector('paper-textarea[name="zig"]');
+      var paperTextareaBlank = form.querySelector('paper-textarea[name="blank"]');
 
       assert.equal(customElement.value, 'zag');
       assert.equal(input.value, 'bar');
+      assert.equal(inputBlank.value, '');
       assert.isTrue(checkbox1.checked);
       assert.isFalse(checkbox2.checked);
       assert.equal(paperInput.value, 'zug');
       assert.equal(paperInput.inputElement.value, 'zug');
+      assert.equal(paperInputBlank.value, '');
+      assert.equal(paperInputBlank.inputElement.value, '');
       assert.equal(paperTextarea.value, 'zog');
       assert.equal(paperTextarea.inputElement.textarea.value, 'zog');
+      assert.equal(paperTextareaBlank.value, '');
+      assert.equal(paperTextareaBlank.inputElement.textarea.value, '');
 
       // Change the values.
       customElement.value = 'not zag';
       input.value = 'not bar';
+      inputBlank.value = 'not blank';
       checkbox1.checked = false;
       checkbox2.checked = true;
       paperInput.value = 'not zug';
+      paperInputBlank.value = 'not blank';
       paperTextarea.value = 'not zog';
+      paperTextareaBlank.value = 'not blank';
 
       assert.equal(customElement.value, 'not zag');
       assert.equal(input.value, 'not bar');
+      assert.equal(inputBlank.value, 'not blank');
       assert.isFalse(checkbox1.checked);
       assert.isTrue(checkbox2.checked);
       assert.equal(paperInput.value, 'not zug');
       assert.equal(paperInput.inputElement.value, 'not zug');
+      assert.equal(paperInputBlank.value, 'not blank');
+      assert.equal(paperInputBlank.inputElement.value, 'not blank');
       assert.equal(paperTextarea.value, 'not zog');
       assert.equal(paperTextarea.inputElement.textarea.value, 'not zog');
+      assert.equal(paperTextareaBlank.value, 'not blank');
+      assert.equal(paperTextareaBlank.inputElement.textarea.value, 'not blank');
 
       form.addEventListener('iron-form-reset', function(event) {
         // Restored initial values.
         assert.equal(customElement.value, 'zag');
         assert.equal(input.value, 'bar');
+        assert.equal(inputBlank.value, '');
         assert.isTrue(checkbox1.checked);
         assert.isFalse(checkbox2.checked);
         assert.equal(paperInput.value, 'zug');
         assert.equal(paperInput.inputElement.value, 'zug');
+        assert.equal(paperInputBlank.value, '');
+        assert.equal(paperInputBlank.inputElement.value, '');
         assert.equal(paperTextarea.value, 'zog');
         assert.equal(paperTextarea.inputElement.textarea.value, 'zog');
+        assert.equal(paperTextareaBlank.value, '');
+        assert.equal(paperTextareaBlank.inputElement.textarea.value, '');
         done();
       });
 
@@ -501,30 +525,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Initial values.
       var customElement = form.querySelector('simple-element');
       var input = form.querySelector('input[name="foo"]');
+      var inputBlank = form.querySelector('input[name="blank"]');
       var checkbox1 = form.querySelectorAll('input[type="checkbox"]')[0];
       var checkbox2 = form.querySelectorAll('input[type="checkbox"]')[1];
-      var paperInput = form.querySelector('paper-input');
+      var paperInput = form.querySelector('paper-input[name="zig"]');
+      var paperInputBlank = form.querySelector('paper-input[name="blank"]');
       var paperTextarea = form.querySelector('paper-textarea[name="zig"]');
+      var paperTextareaBlank = form.querySelector('paper-textarea[name="blank"]');
 
       assert.equal(customElement.value, 'zag');
       assert.equal(input.value, 'bar');
+      assert.equal(inputBlank.value, '');
       assert.isTrue(checkbox1.checked);
       assert.isFalse(checkbox2.checked);
       assert.equal(paperInput.value, 'zug');
       assert.equal(paperInput.inputElement.value, 'zug');
+      assert.equal(paperInputBlank.value, '');
+      assert.equal(paperInputBlank.inputElement.value, '');
       assert.equal(paperTextarea.value, 'zog');
       assert.equal(paperTextarea.inputElement.textarea.value, 'zog');
+      assert.equal(paperTextareaBlank.value, '');
+      assert.equal(paperTextareaBlank.inputElement.textarea.value, '');
 
       form.addEventListener('iron-form-reset', function(event) {
         // Restored initial values.
         assert.equal(customElement.value, 'zag');
         assert.equal(input.value, 'bar');
+        assert.equal(inputBlank.value, '');
         assert.isTrue(checkbox1.checked);
         assert.isFalse(checkbox2.checked);
         assert.equal(paperInput.value, 'zug');
         assert.equal(paperInput.inputElement.value, 'zug');
+        assert.equal(paperInputBlank.value, '');
+        assert.equal(paperInputBlank.inputElement.value, '');
         assert.equal(paperTextarea.value, 'zog');
         assert.equal(paperTextarea.inputElement.textarea.value, 'zog');
+        assert.equal(paperTextareaBlank.value, '');
+        assert.equal(paperTextareaBlank.inputElement.textarea.value, '');
         done();
       });
 


### PR DESCRIPTION
The fix from #144 had an unintended side effect of resetting Initially blank inputs to null. This patch fixes the problem by setting the `null` conditionally based on an explicit check for `undefined`.

Also added some unit tests to verify that initially blank inputs can be properly reset to blank.