### PR TITLE
Validate extended elements that do not implement iron-form-element-behavior

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,6 +37,7 @@
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "^0.7.0"
+    "webcomponentsjs": "^0.7.0",
+    "iron-input": "^1.0.10"
   }
 }

--- a/iron-form.html
+++ b/iron-form.html
@@ -393,7 +393,7 @@ event and do your own custom submission:
 
         // Custom elements that extend a native element will also appear in
         // this list, but they've already been validated.
-        if (!el.hasAttribute('is') && el.willValidate && el.checkValidity) {
+        if (this._customElements.indexOf(el) === -1 && el.willValidate && el.checkValidity) {
           valid = el.checkValidity() && valid;
         }
       }

--- a/test/basic.html
+++ b/test/basic.html
@@ -18,6 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../polymer/polymer.html">
   <link rel="import" href="../../paper-input/paper-input.html">
   <link rel="import" href="../../paper-input/paper-textarea.html">
+  <link rel="import" href="../../iron-input/iron-input.html">
   <link rel="import" href="../iron-form.html">
   <link rel="import" href="simple-element.html">
   <link rel="import" href="element-with-nested-form-element.html">
@@ -32,6 +33,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <form is="iron-form">
         <simple-element name="zig" value="zag"></simple-element>
         <input name="foo" value="bar">
+      </form>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="ExtendedElement">
+    <template>
+      <form is="iron-form">
+        <input is="iron-input" name="foo" required>
       </form>
     </template>
   </test-fixture>
@@ -346,6 +355,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(f.elements.length, 1);
       assert.isFalse(f.$$('simple-element').validate());
       assert.isFalse(f.$$('input').checkValidity());
+    });
+
+    test('extended native elements that do not implement iron-form-element-behavior are validated', function() {
+      var f = fixture('ExtendedElement');
+
+      assert.isFalse(f.validate());
     });
   });
 


### PR DESCRIPTION
Fixes #123

I think the issue is that an extended element that doesn't implement `iron-form-element-behavior` never registers itself with the `iron-form`.  This means it isn't in the `_customElements` array and never has its validation checked. It didn't seem like you would want to add that behavior to all iron-inputs, so I changed the conditional to check to see if the custom element is in the list of `_customElements` rather than just seeing if it is an `is=` element.
