### PR TITLE
2.0 preview slotted form fields

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -358,8 +358,8 @@ attach it to the `<iron-form>`:
           var el = nodes[i];
           if (el.tagName === "SLOT") {
             var distributed = Polymer.dom(el).getDistributedNodes();
-            for (var i = 0; i < distributed.length; i++) {
-              var additionalElements = this._getFormElements(distributed[i]);
+            for (var j = 0; j < distributed.length; j++) {
+              var additionalElements = this._getFormElements(distributed[j]);
               result.push.apply(result, additionalElements);
             }
           } else {

--- a/iron-form.html
+++ b/iron-form.html
@@ -364,19 +364,35 @@ attach it to the `<iron-form>`:
         var nodes = Polymer.dom(this._form).children;
         var submittable = [];
 
-        for (var i = 0; i < nodes.length; i++) {
-          // This element might contain other potentially submittable elements
-          // which we need to look at. For example, this could be a <p> node
-          // containing a bunch of inputs.
-          var elements = Array.prototype.slice.call(Polymer.dom(nodes[i]).querySelectorAll('*')) || [];
+        // handle <iron-input><input /></iron-input> scenario
+        var duplicateIndex = function(name) {
+          var isArray = name[name.length - 1] === ']' && name.indexOf('[') > -1;
+          if (!isArray) {
+            for (var i = 0; i < submittable.length; i++) {
+              if (submittable[i].name === name) {
+                return i;
+              }
+            }
+          }
+        };
 
-          // We also want to check this element.
-          elements.push(nodes[i]);
+        for (var i = 0; i < nodes.length; i++) {
+          var el = nodes[i];
 
           // An element is submittable if it is not disabled, and if it has a
           // 'name' attribute.
-          for (var el, j = 0; el = elements[j], j < elements.length; j++) {
-            if (!el.disabled && el.name) {
+          if (!el.disabled && el.name) {
+            var duplicate = duplicateIndex(el.name);
+            if (duplicate) {
+              var duplicateEl = submittable[duplicate];
+              if (Array.isArray(duplicateEl)) {
+                duplicateEl.push(el);
+              } else {
+                var duplicates = [duplicateEl, el];
+                duplicates.name = el.name;
+                submittable.splice(duplicate, 1, duplicates);
+              }
+            } else {
               submittable.push(el);
             }
           }
@@ -402,6 +418,19 @@ attach it to the `<iron-form>`:
         // 4. <input> can have a whole bunch of behaviours, so it's handled separately.
         // 5. Buttons are hard. The button that was clicked to submit the form
         //    is the one who's name/value gets sent to the server.
+
+        if (Array.isArray(element)) {
+          // Got duplicate elements (with the same name).
+          // Use first non-empty value.
+          for (var i = 0; i < element.length; i++) {
+            var result = this._serializeElementValues(element[i]);
+            if (result && result.length > 0) {
+              return result;
+            }
+          }
+          return [];
+        }
+
         var tag = element.tagName.toLowerCase();
         if (tag === 'button' || (tag === 'input' && (element.type === 'submit' || element.type === 'reset'))) {
           return [];

--- a/iron-form.html
+++ b/iron-form.html
@@ -412,19 +412,6 @@ attach it to the `<iron-form>`:
         // 4. <input> can have a whole bunch of behaviours, so it's handled separately.
         // 5. Buttons are hard. The button that was clicked to submit the form
         //    is the one who's name/value gets sent to the server.
-
-        if (Array.isArray(element)) {
-          // Got duplicate elements (with the same name).
-          // Use first non-empty value.
-          for (var i = 0; i < element.length; i++) {
-            var result = this._serializeElementValues(element[i]);
-            if (result && result.length > 0) {
-              return result;
-            }
-          }
-          return [];
-        }
-
         var tag = element.tagName.toLowerCase();
         if (tag === 'button' || (tag === 'input' && (element.type === 'submit' || element.type === 'reset'))) {
           return [];

--- a/iron-form.html
+++ b/iron-form.html
@@ -382,37 +382,13 @@ attach it to the `<iron-form>`:
         var nodes = this._getFormElements();
         var submittable = [];
 
-        // handle <iron-input><input /></iron-input> scenario
-        var duplicateIndex = function(name) {
-          var isArray = name[name.length - 1] === ']' && name.indexOf('[') > -1;
-          if (!isArray) {
-            for (var i = 0; i < submittable.length; i++) {
-              if (submittable[i].name === name) {
-                return i;
-              }
-            }
-          }
-        };
-
         for (var i = 0; i < nodes.length; i++) {
           var el = nodes[i];
 
           // An element is submittable if it is not disabled, and if it has a
           // 'name' attribute.
           if (!el.disabled && el.name) {
-            var duplicate = duplicateIndex(el.name);
-            if (duplicate) {
-              var duplicateEl = submittable[duplicate];
-              if (Array.isArray(duplicateEl)) {
-                duplicateEl.push(el);
-              } else {
-                var duplicates = [duplicateEl, el];
-                duplicates.name = el.name;
-                submittable.splice(duplicate, 1, duplicates);
-              }
-            } else {
-              submittable.push(el);
-            }
+            submittable.push(el);
           }
         }
         return submittable;

--- a/iron-form.html
+++ b/iron-form.html
@@ -88,7 +88,7 @@ attach it to the `<iron-form>`:
     </style>
 
     <!-- This form is used to collect the elements that should be submitted -->
-    <slot></slot>
+    <slot id="content"></slot>
 
     <!-- This form is used for submission -->
     <form id="helper" action$="[[action]]" method$="[[method]]" enctype$="[[enctype]]"></form>
@@ -124,13 +124,6 @@ attach it to the `<iron-form>`:
           type: Boolean,
           value: false
         },
-        /**
-         * Setting to true skips validation before submit
-         */
-        novalidate: {
-          type: Boolean,
-          value: false,
-        },
       },
 
       /**
@@ -160,32 +153,11 @@ attach it to the `<iron-form>`:
       */
 
       attached: function() {
-        this._nodeObserver = Polymer.dom(this).observeNodes(
-          function(mutations) {
-            for (var i = 0; i < mutations.addedNodes.length; i++) {
-              if (mutations.addedNodes[i].tagName === 'FORM') {
-                if (!this._alreadyCalledInit) {
-                  this._alreadyCalledInit = true;
-                  this._form = mutations.addedNodes[i];
-                  this._init();
-                }
-              }
-            }
-          }.bind(this));
+        this._saveDefaultValues();
       },
 
-      detached: function() {
-        if (this._nodeObserver) {
-          Polymer.dom(this).unobserveNodes(this._nodeObserver);
-          this._nodeObserver = null;
-        }
-      },
-
-      _init: function() {
-        this._form.addEventListener('submit', this.submit.bind(this));
-        this._form.addEventListener('reset', this.reset.bind(this));
-
-        // Save the initial values.
+      _saveDefaultValues: function() {
+        var nodes = this._getFormElements();
         this._defaults = this._defaults || new WeakMap();
         var nodes = this._getFormElements();
         for (var i = 0; i < nodes.length; i++) {
@@ -204,7 +176,7 @@ attach it to the `<iron-form>`:
        * @return {boolean} True if all the elements are valid.
        */
       validate: function() {
-        if (this.novalidate)
+        if (this._form.getAttribute('novalidate') === '')
           return true;
 
         // Start by making the form check the native elements it knows about.
@@ -357,20 +329,34 @@ attach it to the `<iron-form>`:
         return validatable;
       },
 
-      _getFormElements: function(root) {
-        if (!root) root = this._form;
-        var nodes = Polymer.dom(root).querySelectorAll('*');
+      _getFormElements: function(rootSlot) {
+        if (!rootSlot) rootSlot = this.$.content;
+        if (!rootSlot.__formListener) {
+          rootSlot.__formListener = () => this._saveDefaultValues(rootSlot);
+          rootSlot.__formListener();
+          rootSlot.addEventListener('slotchange', rootSlot.__formListener);
+        }
         var result = [];
-        for (var i = 0; i < nodes.length; i++) {
-          var el = nodes[i];
-          if (el.tagName === "SLOT") {
-            var distributed = Polymer.dom(el).getDistributedNodes();
-            for (var j = 0; j < distributed.length; j++) {
-              var additionalElements = this._getFormElements(distributed[j]);
-              result.push.apply(result, additionalElements);
-            }
+        var addElement = el => {
+          if (el !== this._form && el.tagName === "FORM") {
+            this._form = el;
+            this._form.addEventListener('submit', this.submit.bind(this));
+            this._form.addEventListener('reset', this.reset.bind(this));
+          } else if (el.tagName === "SLOT") {
+            var additionalElements = this._getFormElements(el);
+            result.push.apply(result, additionalElements);
           } else {
             result.push(el);
+          }
+        };
+        var roots = rootSlot.assignedNodes()
+                            .filter(n => n.nodeType === Node.ELEMENT_NODE);
+        for (var rootNo = 0; rootNo < roots.length; rootNo++) {
+          var root = roots[rootNo];
+          addElement(root);
+          var nodes = root.querySelectorAll('*');
+          for (var nodeNo = 0; nodeNo < nodes.length; nodeNo++) {
+            addElement(nodes[nodeNo]);
           }
         }
         return result;

--- a/iron-form.html
+++ b/iron-form.html
@@ -156,6 +156,10 @@ attach it to the `<iron-form>`:
         this._saveDefaultValues();
       },
 
+      detached: function() {
+        this._removeSlotListeners();
+      },
+
       _saveDefaultValues: function() {
         var nodes = this._getFormElements();
         this._defaults = this._defaults || new WeakMap();
@@ -329,15 +333,37 @@ attach it to the `<iron-form>`:
         return validatable;
       },
 
-      _getFormElements: function(rootSlot) {
-        if (!rootSlot) rootSlot = this.$.content;
-        if (!rootSlot.__formListener) {
-          rootSlot.__formListener = () => this._saveDefaultValues(rootSlot);
-          rootSlot.__formListener();
-          rootSlot.addEventListener('slotchange', rootSlot.__formListener);
+      _removeSlotListeners: function(slot) {
+        if (!slot) slot = this.$.content;
+        if (slot.tagName !== "SLOT") return;
+        if (slot.__formListener) {
+          slot.removeEventListener('slotchange', slot.__formListener);
+          delete slot.__formListener;
+        }
+        this._forEachDistributedElement(slot, this._removeSlotListeners.bind(this));
+      },
+
+      _forEachDistributedElement: function(slot, handler) {
+        var roots = slot.assignedNodes().filter(n => n.nodeType === Node.ELEMENT_NODE);
+        for (var rootNo = 0; rootNo < roots.length; rootNo++) {
+          var root = roots[rootNo];
+          handler(root);
+          var children = root.querySelectorAll('*');
+          for (var nodeNo = 0; nodeNo < children.length; nodeNo++) {
+            handler(children[nodeNo]);
+          }
+        }
+      },
+
+      _getFormElements: function(slot) {
+        if (!slot) slot = this.$.content;
+        if (!slot.__formListener) {
+          slot.__formListener = () => this._saveDefaultValues(slot);
+          slot.__formListener();
+          slot.addEventListener('slotchange', slot.__formListener);
         }
         var result = [];
-        var addElement = el => {
+        this._forEachDistributedElement(slot, el => {
           if (el !== this._form && el.tagName === "FORM") {
             this._form = el;
             this._form.addEventListener('submit', this.submit.bind(this));
@@ -348,17 +374,7 @@ attach it to the `<iron-form>`:
           } else {
             result.push(el);
           }
-        };
-        var roots = rootSlot.assignedNodes()
-                            .filter(n => n.nodeType === Node.ELEMENT_NODE);
-        for (var rootNo = 0; rootNo < roots.length; rootNo++) {
-          var root = roots[rootNo];
-          addElement(root);
-          var nodes = root.querySelectorAll('*');
-          for (var nodeNo = 0; nodeNo < nodes.length; nodeNo++) {
-            addElement(nodes[nodeNo]);
-          }
-        }
+        });
         return result;
       },
 

--- a/iron-form.html
+++ b/iron-form.html
@@ -344,7 +344,9 @@ attach it to the `<iron-form>`:
       },
 
       _forEachDistributedElement: function(slot, handler) {
-        var roots = slot.assignedNodes().filter(n => n.nodeType === Node.ELEMENT_NODE);
+        var roots = slot.assignedNodes().filter(function(n) {
+          return n.nodeType === Node.ELEMENT_NODE;
+        });
         for (var rootNo = 0; rootNo < roots.length; rootNo++) {
           var root = roots[rootNo];
           handler(root);
@@ -358,12 +360,14 @@ attach it to the `<iron-form>`:
       _getFormElements: function(slot) {
         if (!slot) slot = this.$.content;
         if (!slot.__formListener) {
-          slot.__formListener = () => this._saveDefaultValues(slot);
+          slot.__formListener = (function() {
+            this._saveDefaultValues(slot);
+          }).bind(this);
           slot.__formListener();
           slot.addEventListener('slotchange', slot.__formListener);
         }
         var result = [];
-        this._forEachDistributedElement(slot, el => {
+        this._forEachDistributedElement(slot, (function(el) {
           if (el !== this._form && el.tagName === "FORM") {
             this._form = el;
             this._form.addEventListener('submit', this.submit.bind(this));
@@ -374,7 +378,7 @@ attach it to the `<iron-form>`:
           } else {
             result.push(el);
           }
-        });
+        }).bind(this));
         return result;
       },
 

--- a/iron-form.html
+++ b/iron-form.html
@@ -342,19 +342,9 @@ attach it to the `<iron-form>`:
         var validatable = [];
 
         for (var i = 0; i < nodes.length; i++) {
-          // This element might contain other potentially validatable elements
-          // which we need to look at. For example, this could be a <p> node
-          // containing a bunch of inputs.
-          var elements = Array.prototype.slice.call(Polymer.dom(nodes[i]).querySelectorAll('*')) || [];
-
-          // We also want to check this element.
-          elements.push(nodes[i]);
-
-          // An element is validatable if it is not disabled
-          for (var el, j = 0; el = elements[j], j < elements.length; j++) {
-            if (!el.disabled) {
-              validatable.push(el);
-            }
+          var el = nodes[i];
+          if (!el.disabled) {
+            validatable.push(el);
           }
         }
         return validatable;

--- a/iron-form.html
+++ b/iron-form.html
@@ -180,7 +180,7 @@ attach it to the `<iron-form>`:
 
         // Save the initial values.
         this._defaults = this._defaults || new WeakMap();
-        var nodes = this._getSubmittableElements();
+        var nodes = this._getFormElements();
         for (var i = 0; i < nodes.length; i++) {
           var node = nodes[i];
           if (!this._defaults.has(node)) {
@@ -263,7 +263,7 @@ attach it to the `<iron-form>`:
           return;
 
         // Load the initial values.
-        var nodes = this._getSubmittableElements();
+        var nodes = this._getFormElements();
         for (var i = 0; i < nodes.length; i++) {
           var node = nodes[i];
           if (this._defaults.has(node)) {
@@ -338,7 +338,7 @@ attach it to the `<iron-form>`:
       },
 
       _getValidatableElements: function() {
-        var nodes = Polymer.dom(this._form).children;
+        var nodes = this._getFormElements();
         var validatable = [];
 
         for (var i = 0; i < nodes.length; i++) {
@@ -360,8 +360,27 @@ attach it to the `<iron-form>`:
         return validatable;
       },
 
+      _getFormElements: function(root) {
+        if (!root) root = this._form;
+        var nodes = Polymer.dom(root).querySelectorAll('*');
+        var result = [];
+        for (var i = 0; i < nodes.length; i++) {
+          var el = nodes[i];
+          if (el.tagName === "SLOT") {
+            var distributed = Polymer.dom(el).getDistributedNodes();
+            for (var i = 0; i < distributed.length; i++) {
+              var additionalElements = this._getFormElements(distributed[i]);
+              result.push.apply(result, additionalElements);
+            }
+          } else {
+            result.push(el);
+          }
+        }
+        return result;
+      },
+
       _getSubmittableElements: function() {
-        var nodes = Polymer.dom(this._form).children;
+        var nodes = this._getFormElements();
         var submittable = [];
 
         // handle <iron-input><input /></iron-input> scenario

--- a/iron-form.html
+++ b/iron-form.html
@@ -124,6 +124,13 @@ attach it to the `<iron-form>`:
           type: Boolean,
           value: false
         },
+        /**
+         * Setting to true skips validation before submit
+         */
+        novalidate: {
+          type: Boolean,
+          value: false,
+        },
       },
 
       /**
@@ -197,7 +204,7 @@ attach it to the `<iron-form>`:
        * @return {boolean} True if all the elements are valid.
        */
       validate: function() {
-        if (this._form.getAttribute('novalidate') === '')
+        if (this.novalidate)
           return true;
 
         // Start by making the form check the native elements it knows about.

--- a/test/basic.html
+++ b/test/basic.html
@@ -116,6 +116,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </form>
         </iron-form>
 
+        <iron-form id="required-novalidate" novalidate>
+          <form action="/get" method="get">
+            <input required>
+          </form>
+        </iron-form>
+
         <iron-form id="native-invalid">
           <form action="/get" method="get">
             <input pattern="aa" value="b">
@@ -363,6 +369,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(responses).to.be.equal(0);
           done();
         },  200);
+      });
+
+      test('novalidate skips the validation', function(done) {
+        var form = f.querySelector('#required-novalidate');
+
+        form.addEventListener('iron-form-response', function(event) {
+          expect(event.detail.response.success).to.be.equal(true);
+          done();
+        });
+
+        // Wait one tick for observeNodes.
+        Polymer.Base.async(function() {
+          expect(form.validate()).to.be.equal(true);
+          form.submit();
+          server.respond();
+        }, 1);
       });
 
       test('invalid <input> but not required is validated and does not submit the form', function(done) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -116,8 +116,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </form>
         </iron-form>
 
-        <iron-form id="required-novalidate" novalidate>
-          <form action="/get" method="get">
+        <iron-form id="required-novalidate">
+          <form action="/get" method="get" novalidate>
             <input required>
           </form>
         </iron-form>
@@ -545,6 +545,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         });
 
+         // enctype is set in template
          form.headers = {'x-some': 'header-value'};
          form.withCredentials = true;
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -29,9 +29,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div>
         <iron-form id="native-checkboxes">
           <form action="/get" method="get">
-            <input type="checkbox" name="check1[]" checked> <!-- default value is "on" -->
-            <input type="checkbox" name="check1[]" value="1">
-            <input type="checkbox" name="check1[]" value="2" checked>
+            <input type="checkbox" name="check1" checked> <!-- default value is "on" -->
+            <input type="checkbox" name="check1" value="1">
+            <input type="checkbox" name="check1" value="2" checked>
             <input type="checkbox" name="check2" value="3" checked>
             <input type="checkbox" name="check3" value="4">
           </form>
@@ -93,9 +93,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </iron-form>
         <iron-form id="custom-inputs">
           <form action="/get" method="get">
-            <paper-input name="input1[]" value=""></paper-input>
-            <paper-input name="input1[]" value="foo"></paper-input>
-            <paper-input name="input1[]" value="zag"></paper-input>
+            <paper-input name="input1" value=""></paper-input>
+            <paper-input name="input1" value="foo"></paper-input>
+            <paper-input name="input1" value="zag"></paper-input>
             <paper-input name="input2" value="bar"></paper-input>
             <paper-input type="password" name="pass1" value="pass"></paper-input>
             <paper-input type="number" name="number1" value="35"></paper-input>
@@ -203,7 +203,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('serializes native checkboxes', function(done) {
         var form = f.querySelector('#native-checkboxes');
         form.addEventListener('iron-form-response', function(event) {
-          var expectedUrl = encodeURI('/get?check1[]=on&check1[]=2&check2=3');
+          var expectedUrl = encodeURI('/get?check1=on&check1=2&check2=3');
           expect(event.detail.url).to.equal(expectedUrl);
           expect(event.detail.response.success).to.be.equal(true);
           done();
@@ -266,8 +266,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var form = f.querySelector('#native-inputs');
 
         form.addEventListener('iron-form-response', function(event) {
-          // TODO(noms): figure out if we should submit empty text.
-          expect(event.detail.url).to.equal('/get?input1=foo&input1=zag&input2=bar&pass1=pass&number1=35');
+          expect(event.detail.url).to.equal('/get?input1=&input1=foo&input1=zag&input2=bar&pass1=pass&number1=35&empty=&empty=');
           expect(event.detail.response.success).to.be.equal(true);
           done();
         });
@@ -312,7 +311,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('serializes custom inputs', function(done) {
         var form = f.querySelector('#custom-inputs');
         form.addEventListener('iron-form-response', function(event) {
-          var expected = '/get?input1[]=foo&input1[]=zag&input2=bar&pass1=pass&number1=35';
+          var expected = '/get?input1=&input1=foo&input1=zag&input2=bar&pass1=pass&number1=35&empty=&empty=';
           expect(event.detail.url).to.equal(encodeURI(expected));
           expect(event.detail.response.success).to.be.equal(true);
           done();

--- a/test/basic.html
+++ b/test/basic.html
@@ -29,9 +29,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div>
         <iron-form id="native-checkboxes">
           <form action="/get" method="get">
-            <input type="checkbox" name="check1" checked> <!-- default value is "on" -->
-            <input type="checkbox" name="check1" value="1">
-            <input type="checkbox" name="check1" value="2" checked>
+            <input type="checkbox" name="check1[]" checked> <!-- default value is "on" -->
+            <input type="checkbox" name="check1[]" value="1">
+            <input type="checkbox" name="check1[]" value="2" checked>
             <input type="checkbox" name="check2" value="3" checked>
             <input type="checkbox" name="check3" value="4">
           </form>
@@ -93,9 +93,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </iron-form>
         <iron-form id="custom-inputs">
           <form action="/get" method="get">
-            <paper-input name="input1" value=""></paper-input>
-            <paper-input name="input1" value="foo"></paper-input>
-            <paper-input name="input1" value="zag"></paper-input>
+            <paper-input name="input1[]" value=""></paper-input>
+            <paper-input name="input1[]" value="foo"></paper-input>
+            <paper-input name="input1[]" value="zag"></paper-input>
             <paper-input name="input2" value="bar"></paper-input>
             <paper-input type="password" name="pass1" value="pass"></paper-input>
             <paper-input type="number" name="number1" value="35"></paper-input>
@@ -197,7 +197,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('serializes native checkboxes', function(done) {
         var form = f.querySelector('#native-checkboxes');
         form.addEventListener('iron-form-response', function(event) {
-          expect(event.detail.url).to.equal('/get?check1=on&check1=2&check2=3');
+          var expectedUrl = encodeURI('/get?check1[]=on&check1[]=2&check2=3');
+          expect(event.detail.url).to.equal(expectedUrl);
           expect(event.detail.response.success).to.be.equal(true);
           done();
         });
@@ -212,7 +213,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('serializes native radio buttons', function(done) {
         var form = f.querySelector('#native-radios');
         form.addEventListener('iron-form-response', function(event) {
-          expect(event.detail.url).to.equal('/get?radio1=on&radio2=3');
+          var expectedUrl = encodeURI('/get?radio1=on&radio2=3');
+          expect(event.detail.url).to.equal(expectedUrl);
           expect(event.detail.response.success).to.be.equal(true);
           done();
         });
@@ -258,7 +260,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var form = f.querySelector('#native-inputs');
 
         form.addEventListener('iron-form-response', function(event) {
-          expect(event.detail.url).to.equal('/get?input1=&input1=foo&input1=zag&input2=bar&pass1=pass&number1=35&empty=&empty=');
+          // TODO(noms): figure out if we should submit empty text.
+          expect(event.detail.url).to.equal('/get?input1=foo&input1=zag&input2=bar&pass1=pass&number1=35');
           expect(event.detail.response.success).to.be.equal(true);
           done();
         });
@@ -303,7 +306,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('serializes custom inputs', function(done) {
         var form = f.querySelector('#custom-inputs');
         form.addEventListener('iron-form-response', function(event) {
-          expect(event.detail.url).to.equal('/get?input1=&input1=foo&input1=zag&input2=bar&pass1=pass&number1=35&empty=&empty=');
+          var expected = '/get?input1[]=foo&input1[]=zag&input2=bar&pass1=pass&number1=35';
+          expect(event.detail.url).to.equal(encodeURI(expected));
           expect(event.detail.response.success).to.be.equal(true);
           done();
         });

--- a/test/basic.html
+++ b/test/basic.html
@@ -140,7 +140,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="submission">
     <template>
       <iron-form>
-        <form action="/get" method="get">
+        <form action="/get" method="get" enctype="application/json">
           <input type="checkbox" name="check1" checked>
           <input type="submit">
           <input type="button">
@@ -508,6 +508,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Wait one tick for observeNodes.
         Polymer.Base.async(function() {
           form._form.removeAttribute('method');
+          form.submit();
+          server.respond();
+        }, 1);
+      });
+
+      test('enctype, headers and withCredentials works', function(done) {
+        form.addEventListener('iron-form-response', function(event) {
+          var xhr = event.detail.xhr;
+          expect(xhr.withCredentials).to.be.true;
+          var headers = xhr.requestHeaders;
+          expect(headers['content-type']).to.be.equal('application/json');
+          expect(headers['x-some']).to.be.equal('header-value');
+          done();
+        });
+
+         form.headers = {'x-some': 'header-value'};
+         form.withCredentials = true;
+
+        // Wait one tick for observeNodes.
+        Polymer.Base.async(function() {
           form.submit();
           server.respond();
         }, 1);

--- a/test/basic.html
+++ b/test/basic.html
@@ -203,8 +203,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('serializes native checkboxes', function(done) {
         var form = f.querySelector('#native-checkboxes');
         form.addEventListener('iron-form-response', function(event) {
-          var expectedUrl = encodeURI('/get?check1=on&check1=2&check2=3');
-          expect(event.detail.url).to.equal(expectedUrl);
+          expect(event.detail.url).to.equal('/get?check1=on&check1=2&check2=3');
           expect(event.detail.response.success).to.be.equal(true);
           done();
         });
@@ -219,8 +218,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('serializes native radio buttons', function(done) {
         var form = f.querySelector('#native-radios');
         form.addEventListener('iron-form-response', function(event) {
-          var expectedUrl = encodeURI('/get?radio1=on&radio2=3');
-          expect(event.detail.url).to.equal(expectedUrl);
+          expect(event.detail.url).to.equal('/get?radio1=on&radio2=3');
           expect(event.detail.response.success).to.be.equal(true);
           done();
         });
@@ -311,8 +309,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('serializes custom inputs', function(done) {
         var form = f.querySelector('#custom-inputs');
         form.addEventListener('iron-form-response', function(event) {
-          var expected = '/get?input1=&input1=foo&input1=zag&input2=bar&pass1=pass&number1=35&empty=&empty=';
-          expect(event.detail.url).to.equal(encodeURI(expected));
+          expect(event.detail.url).to.equal('/get?input1=&input1=foo&input1=zag&input2=bar&pass1=pass&number1=35&empty=&empty=');
           expect(event.detail.response.success).to.be.equal(true);
           done();
         });

--- a/test/index.html
+++ b/test/index.html
@@ -14,7 +14,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       WCT.loadSuites([
         'basic.html?wc-shadydom=true&wc-ce=true',
-        'basic.html?dom=shadow'
+        'basic.html?dom=shadow',
+	'slotted.html?wc-shadydom=true&wc-ce=true',
+        'slotted.html?dom=shadow',
       ]);
     </script>
 

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       WCT.loadSuites([
         'basic.html?wc-shadydom=true&wc-ce=true',
         'basic.html?dom=shadow',
-	'slotted.html?wc-shadydom=true&wc-ce=true',
+        'slotted.html?wc-shadydom=true&wc-ce=true',
         'slotted.html?dom=shadow',
       ]);
     </script>

--- a/test/slotted.html
+++ b/test/slotted.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <!--
 @license
-Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt

--- a/test/slotted.html
+++ b/test/slotted.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../../polymer/polymer.html">
   <link rel="import" href="../../paper-checkbox/paper-checkbox.html">
-  <link rel="import" href="../../iron-input/iron-input.html">
+  <link rel="import" href="../../paper-input/paper-input.html">
   <link rel="import" href="../iron-form.html">
 
 </head>
@@ -71,8 +71,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <input type="radio" name="radio2">
           <paper-checkbox name="papercheck1" checked></paper-checkbox>
           <paper-checkbox name="papercheck2"></paper-checkbox>
-          <iron-input bind-value="paper1"><input name="paper1" /></iron-input>
-          <iron-input bind-value=""><input name="paper2" /></iron-input>
+          <paper-input name="paper1" value="paper1"></paper-input>
+          <paper-input name="paper2" value=""></paper-input>
           <input type="reset">
         </div>
       </slotted-form>
@@ -179,7 +179,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           form.reset();
 
           var final = form.serializeForm();
-          expect(JSON.stringify(initial)).to.be.equal(JSON.stringify(final));
+          expect(JSON.stringify(final)).to.be.equal(JSON.stringify(initial));
           done();
         }, 1);
       });

--- a/test/slotted.html
+++ b/test/slotted.html
@@ -32,7 +32,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </iron-form>
     </template>
     <script>
+    HTMLImports.whenReady(function() {
       Polymer({is: 'slotted-form'});
+    });
     </script>
   </dom-module>
 

--- a/test/slotted.html
+++ b/test/slotted.html
@@ -1,0 +1,187 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <title>iron-form</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../../polymer/polymer.html">
+  <link rel="import" href="../../paper-checkbox/paper-checkbox.html">
+  <link rel="import" href="../../iron-input/iron-input.html">
+  <link rel="import" href="../iron-form.html">
+
+</head>
+<body>
+  <dom-module id="slotted-form">
+    <template>
+      <iron-form id="form">
+        <form action="/get" method="get">
+          <input name="original" value="works" />
+          <slot name="inputs"></slot>
+        </form>
+      </iron-form>
+    </template>
+    <script>
+      Polymer({is: 'slotted-form'});
+    </script>
+  </dom-module>
+
+  <test-fixture id="slotted">
+    <template>
+      <slotted-form>
+        <div slot="inputs">
+          <paper-checkbox name="checkbox" checked></paper-checkbox>
+          <input name="input" value="some" />
+        </div>
+      </slotted-form>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="slotted-validation">
+    <template>
+      <slotted-form>
+        <div slot="inputs">
+          <paper-checkbox required></paper-checkbox>
+        </div>
+      </slotted-form>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="slotted-reset">
+    <template>
+      <slotted-form>
+        <div slot="inputs">
+          <input type="input" name="input1" value="input1">
+          <input type="input" name="input2">
+          <input type="checkbox" name="check1" checked>
+          <input type="checkbox" name="check2">
+          <input type="radio" name="radio1" checked>
+          <input type="radio" name="radio2">
+          <paper-checkbox name="papercheck1" checked></paper-checkbox>
+          <paper-checkbox name="papercheck2"></paper-checkbox>
+          <iron-input bind-value="paper1"><input name="paper1" /></iron-input>
+          <iron-input bind-value=""><input name="paper2" /></iron-input>
+          <input type="reset">
+        </div>
+      </slotted-form>
+    </template>
+  </test-fixture>
+
+
+
+  <script>
+    suite('slotted', function() {
+      var form;
+      var server;
+
+      setup(function() {
+        server = sinon.fakeServer.create();
+        server.respondWith(
+          'GET',
+          /\/get.*/,
+          [
+            200,
+            '{"Content-Type":"application/json"}',
+            '{"success":true}'
+          ]
+        );
+      });
+
+      teardown(function() {
+        server.restore();
+      });
+
+      suite('serialization', function() {
+        setup(function() {
+          form = fixture('slotted').$.form;
+        });
+        test('serializes both normal and distributed nodes', function(done) {
+          form.addEventListener('iron-form-response', function(event) {
+            var expectedUrl = encodeURI('/get?original=works&checkbox=on&input=some');
+            expect(event.detail.url).to.equal(expectedUrl);
+            expect(event.detail.response.success).to.be.equal(true);
+            done();
+          });
+
+          // Wait one tick for observeNodes.
+          Polymer.Base.async(function() {
+            form.submit();
+            server.respond();
+          }, 1);
+        });
+      });
+
+      suite('validation', function() {
+        setup(function() {
+          form = fixture('slotted-validation').$.form;
+        });
+        test('<paper-checkbox required> is validated and does not submit the form', function(done) {
+          var responses = 0;
+          form.addEventListener('iron-form-response', function(event) {
+            responses++;
+          });
+
+          // Wait one tick for observeNodes.
+          Polymer.Base.async(function() {
+            expect(form.validate()).to.be.equal(false);
+            form.submit();
+            server.respond();
+          }, 1);
+
+          setTimeout(function() {
+            expect(responses).to.be.equal(0);
+            done();
+          },  200);
+        });
+      });
+    });
+
+    suite('resetting', function() {
+      var inputs;
+      setup(function() {
+        form = fixture('slotted-reset').$.form;
+        inputs = Polymer.dom(form.querySelector('slot')).getDistributedNodes()[0];
+      })
+      test('can reset a form', function(done) {
+        // Wait one tick for observeNodes.
+        Polymer.Base.async(function() {
+          var initial = form.serializeForm();
+          expect(JSON.stringify(initial)).to.be.equal('{"original":"works","input1":"input1","input2":"","check1":"on","radio1":"on","papercheck1":"on","paper1":"paper1","paper2":""}');
+
+          // Modify all the values, flip all the inputs.
+          form.querySelector('[name=original]').value = 'works++';
+          inputs.querySelector('[name=input1').value = 'input1++';
+          inputs.querySelector('[name=input2').value = 'input2++';
+          inputs.querySelector('[name=check1').checked = false;
+          inputs.querySelector('[name=check2').checked = true;
+          inputs.querySelector('[name=radio1').checked = false;
+          inputs.querySelector('[name=radio2').checked = true;
+          inputs.querySelector('[name=papercheck1').checked = false;
+          inputs.querySelector('[name=papercheck2').checked = true;
+          inputs.querySelector('[name=paper1').value = 'paper1++';
+          inputs.querySelector('[name=paper2').value = 'paper2++';
+
+          var updated = form.serializeForm();
+          expect(JSON.stringify(updated)).to.not.be.equal(initial);
+
+          form.reset();
+
+          var final = form.serializeForm();
+          expect(JSON.stringify(initial)).to.be.equal(JSON.stringify(final));
+          done();
+        }, 1);
+      });
+    });
+
+  </script>
+</body>


### PR DESCRIPTION
- Fixes tests (changes paper-input to iron-input) because of [this issue](https://github.com/Polymer/polymer/issues/4049).
- Fixes form reset by saving initial values.
- Differentiates array type of form fields (`name="someArray[]"`) and no longer duplicates non-array fields with the same name.
- Adds slot support (distributed nodes):

``` html
<iron-form>
  <form>
    <slot></slot>
  </form>
</iron-form>
```
