### PR TITLE
Fixes issue #162 - iron-form element does not serialise all duplicates if the first one has value equal to empty string

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -292,7 +292,7 @@ event and do your own custom submission:
       function addSerializedElement(name, value) {
         // If the name doesn't exist, add it. Otherwise, serialize it to
         // an array,
-        if (!json[name]) {
+        if (json[name] === undefined) {
           json[name] = value;
         } else {
           if (!Array.isArray(json[name])) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -41,7 +41,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <form is="iron-form">
         <input name="foo" value="bar">
         <input name="foo" value="barbar">
-        <input name="foo" value="">
+        <input name="empty" value="">
+        <input name="empty" value="">
         <simple-element name="zig" value="zig"></simple-element>
         <simple-element name="zig" value="zag"></simple-element>
         <simple-element name="zig" value="zug"></simple-element>
@@ -368,14 +369,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       f = fixture('Dupes');
 
       assert.equal(f._customElements.length, 3);
-      assert.equal(f.elements.length, 3);
+      assert.equal(f.elements.length, 4);
 
       var json = f.serialize();
-      assert.equal(Object.keys(json).length, 2);
-      assert.equal(json['foo'].length, 3);
+      assert.equal(Object.keys(json).length, 3);
+      assert.equal(json['foo'].length, 2);
       assert.equal(json['foo'][0], 'bar');
       assert.equal(json['foo'][1], 'barbar');
-      assert.equal(json['foo'][2], '');
+      assert.equal(json['empty'].length, 2);
+      assert.equal(json['empty'][0], '');
+      assert.equal(json['empty'][1], '');
       assert.equal(json['zig'].length, 3);
       assert.equal(json['zig'][0], 'zig');
       assert.equal(json['zig'][1], 'zag');

--- a/test/basic.html
+++ b/test/basic.html
@@ -41,6 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <form is="iron-form">
         <input name="foo" value="bar">
         <input name="foo" value="barbar">
+        <input name="foo" value="">
         <simple-element name="zig" value="zig"></simple-element>
         <simple-element name="zig" value="zag"></simple-element>
         <simple-element name="zig" value="zug"></simple-element>
@@ -367,13 +368,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       f = fixture('Dupes');
 
       assert.equal(f._customElements.length, 3);
-      assert.equal(f.elements.length, 2);
+      assert.equal(f.elements.length, 3);
 
       var json = f.serialize();
       assert.equal(Object.keys(json).length, 2);
-      assert.equal(json['foo'].length, 2);
+      assert.equal(json['foo'].length, 3);
       assert.equal(json['foo'][0], 'bar');
       assert.equal(json['foo'][1], 'barbar');
+      assert.equal(json['foo'][2], '');
       assert.equal(json['zig'].length, 3);
       assert.equal(json['zig'][0], 'zig');
       assert.equal(json['zig'][1], 'zag');


### PR DESCRIPTION
- Added tests to show the problem
- Fixed the problem by checking explicitly for 'undefined' when serialising a value