### PR TITLE
Fix duplication in nested form elements

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -290,7 +290,7 @@ attach it to the `<iron-form>`:
       },
 
       _getValidatableElements: function() {
-        var nodes = Polymer.dom(this._form).querySelectorAll('*');
+        var nodes = Polymer.dom(this._form).children;
         var validatable = [];
 
         for (var i = 0; i < nodes.length; i++) {
@@ -313,7 +313,7 @@ attach it to the `<iron-form>`:
       },
 
       _getSubmittableElements: function() {
-        var nodes = Polymer.dom(this._form).querySelectorAll('*');
+        var nodes = Polymer.dom(this._form).children;
         var submittable = [];
 
         for (var i = 0; i < nodes.length; i++) {


### PR DESCRIPTION
```
<iron-form>
    <form>
        <paper-input name="field1" label="Field 1" type="text"></paper-input>
        <paper-input name="field2" label="Field 2" type="text"></paper-input>
        <paper-input name="field3" label="Field 3" type="text"></paper-input>
        <div>
            <paper-dropdown-menu name="field4" label="Field 4">
                <paper-listbox slot="dropdown-content">
                    <paper-item>Val1</paper-item>
                    <paper-item>Val2</paper-item>
                    <paper-item>Val3</paper-item>
                </paper-listbox>
            </paper-dropdown-menu>
        </div>
    </form>
</iron-form>
```

In this situation `_getSubmittableElements` produces the following output:
```
[paper-input, paper-input, paper-input, paper-dropdown-menu, paper-dropdown-menu]
```
Instead of:
```
[paper-input, paper-input, paper-input, paper-dropdown-menu]
```