### PR TITLE
fixes #184

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -239,7 +239,7 @@ event and do your own custom submission:
       this.request.withCredentials = this.withCredentials;
       this.request.headers = this.headers;
 
-      if (this.method.toUpperCase() === 'POST') {
+      if (this.request.method.toUpperCase() === 'POST') {
         this.request.body = json;
       } else {
         this.request.params = json;


### PR DESCRIPTION
Fixes #184 

TL; DR: `forms` are bananas and have this magical indexing of inputs by their `name` attribute. So if you have something like an `input type='foo'` in a form, you can address that input with `form.foo`.  No, I'm not kidding. Yes, this stomps over the `method` attribute, which is just an attribute and not a property. Sigh.