### PR TITLE
reset: clear validation messages #93

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -286,6 +286,7 @@ attach it to the `<iron-form>`:
             node.value = defaults.value;
             node.checked = defaults.checked;
           }
+          node.invalid = false;
         }
       },
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -197,21 +197,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="resetting">
     <template>
-      <iron-form>
-        <form action="/get" method="get">
-          <input type="input" name="input1" id="input1" value="input1">
-          <input type="input" name="input2" id="input2">
-          <input type="checkbox" name="check1" id="check1" checked>
-          <input type="checkbox" name="check2" id="check2">
-          <input type="radio" name="radio1" id="radio1" checked>
-          <input type="radio" name="radio2" id="radio2">
-          <paper-checkbox name="papercheck1" id="papercheck1" checked></paper-checkbox>
-          <paper-checkbox name="papercheck2" id="papercheck2"></paper-checkbox>
-          <paper-input name="paper1" id="paper1" value="paper1"></paper-input>
-          <paper-input name="paper2" id="paper2" value=""></paper-input>
-          <input type="reset">
-        </form>
-      </iron-form>
+      <div>
+        <iron-form id="with-default-values">
+          <form action="/get" method="get">
+            <input type="input" name="input1" id="input1" value="input1">
+            <input type="input" name="input2" id="input2">
+            <input type="checkbox" name="check1" id="check1" checked>
+            <input type="checkbox" name="check2" id="check2">
+            <input type="radio" name="radio1" id="radio1" checked>
+            <input type="radio" name="radio2" id="radio2">
+            <paper-checkbox name="papercheck1" id="papercheck1" checked></paper-checkbox>
+            <paper-checkbox name="papercheck2" id="papercheck2"></paper-checkbox>
+            <paper-input name="paper1" id="paper1" value="paper1"></paper-input>
+            <paper-input name="paper2" id="paper2" value=""></paper-input>
+            <input type="reset">
+          </form>
+        </iron-form>
+
+        <iron-form id="invalid-named">
+          <form action="/get" method="get">
+            <paper-input name="paper" pattern="aa" value="b"></paper-input>
+          </form>
+        </iron-form>
     </template>
   </test-fixture>
 
@@ -748,8 +755,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('resetting', function() {
+      var f;
+
+      setup(function() {
+        f = fixture('resetting');
+      });
+
       test('can reset a form', function(done) {
-        var form = fixture('resetting');
+        var form = f.querySelector('#with-default-values');
 
         // Wait one tick for observeNodes.
         Polymer.Base.async(function() {
@@ -773,6 +786,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           form.reset();
           var final = form.serializeForm();
           expect(JSON.stringify(initial)).to.be.equal(JSON.stringify(final));
+          done();
+        });
+      });
+
+      test('validation messages are cleared', function(done) {
+        var form = f.querySelector('#invalid-named');
+        var customElement = form.querySelector('paper-input');
+
+        // Wait one tick for observeNodes.
+        Polymer.Base.async(function() {
+          expect(form.validate()).to.be.false;
+          expect(customElement.invalid).to.be.true;
+
+          form.reset();
+          expect(customElement.invalid).to.be.false;
           done();
         });
       });


### PR DESCRIPTION
Fixes #93.

It sets `invalid` attribute to false on every submittable child element (=on element with 'name' attribute).

Test with one `paper-input` element is included.