### PR TITLE
Add default enctype if it is missing from from

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -152,7 +152,7 @@ attach it to the `<iron-form>`:
 
       /**
        * Fired after the form is submitted and an error is received. An
-       * error message is included in event.detail.error and an 
+       * error message is included in event.detail.error and an
        * IronRequestElement is included in event.detail.request.
        *
        * @event iron-form-error
@@ -255,7 +255,7 @@ attach it to the `<iron-form>`:
           // Copy the original form attributes.
           this.$.helper.action = this._form.getAttribute('action');
           this.$.helper.method = this._form.getAttribute('method') || 'GET';
-          this.$.helper.contentType = this._form.getAttribute('enctype');
+          this.$.helper.contentType = this._form.getAttribute('enctype') || 'application/x-www-form-urlencoded';
 
           this.$.helper.submit();
           this.fire('iron-form-submit');
@@ -330,7 +330,7 @@ attach it to the `<iron-form>`:
         // elements with those names.
         this.request.url = this._form.getAttribute('action');
         this.request.method = this._form.getAttribute('method') || 'GET';
-        this.request.contentType = this._form.getAttribute('enctype');
+        this.request.contentType = this._form.getAttribute('enctype') || 'application/x-www-form-urlencoded';
         this.request.withCredentials = this.withCredentials;
         this.request.headers = this.headers;
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -230,6 +230,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <paper-input name="paper2" value="value2"></paper-input>
           </form>
         </iron-form>
+          <iron-form id="plain-form">
+              <form action="/valid/url" method="post" enctype="text/plain">
+                  <paper-input name="paper1" value="value1"></paper-input>
+                  <paper-input name="paper2" value="value2"></paper-input>
+              </form>
+          </iron-form>
         </div>
     </template>
   </test-fixture>
@@ -845,14 +851,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('submits a form with text/plain', function(done) {
-        var form = f.querySelector('#simple-form');
+        var form = f.querySelector('#plain-form');
 
         server.respondWith(
           'POST',
           /\/valid\/url.*/,
           function (request) {
             expect(request.requestHeaders).to.deep.equal({
-                "Content-Type": "text/plain;charset=utf-8",
+                "content-type": "text/plain;charset=utf-8",
                 "accept": "application/json"});
             expect(request.requestBody).to.deep.equal({
                 "paper1": "value1",
@@ -889,6 +895,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             server.respond();
           });
       });
+        test('submits a form with application/x-www-form-urlencoded', function(done) {
+            var form = f.querySelector('#simple-form');
+
+            server.respondWith(
+                'POST',
+                /\/valid\/url.*/,
+                function (request) {
+                    expect(request.requestHeaders).to.deep.equal({
+                        "content-type": "application/x-www-form-urlencoded;charset=utf-8",
+                        "accept": "application/json"});
+                    expect(request.requestBody).to.equal(
+                        'paper1=value1&paper2=value2');
+                    done();
+                }
+            );
+
+            // Wait one tick for observeNodes.
+            Polymer.Base.async(function() {
+                form.submit();
+                server.respond();
+            });
+        });
     });
   </script>
 </body>


### PR DESCRIPTION
This fixes the problem with existing forms not having `enctype` attribute present, iron-form emits `[Object object]` string when the right value is missing.