### PR TITLE
Fixes breaking on iron-form when allow-redirect is on and transpiled in Babel via Webpack

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -248,7 +248,7 @@ attach it to the `<iron-form>`:
         if (this.allowRedirect) {
           // If we're submitting the form natively, then create a hidden element for
           // each of the values.
-          for (element in json) {
+          for (var element in json) {
             this.$.helper.appendChild(this._createHiddenElement(element, json[element]));
           }
 


### PR DESCRIPTION
This is connected to issue #214 