### PR TITLE
fix: avoid to submit the form on registeredCallback

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -198,8 +198,8 @@ event and do your own custom submission:
         // Oh good! We don't handle `required` correctly.
         Polymer.clientSupportsFormValidationUI = false;
         event.preventDefault();
+        button.click();
       });
-      button.click();
     },
 
     ready: function() {


### PR DESCRIPTION
Before this commit the submit button was throwing a click event when the
iron-form web component was registered. Since the browser is giving a
warning because the form is not connected to the document when it's
submitted, we have to not fire the click event at this lifecycle step.

Now, the button fire the click event when the form receives a "submit"
event.

fixes #223