### PR TITLE
Reset native form, fire iron-form-reset event

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,5 +62,3 @@ input, which will be prevented if it exists.
 - the `disableNativeValidationUi` property has been removed: because `iron-form`
 is no longer a type extension, it can't actually trigger any native UI, so
 this property is essentially always true.
-- the `iron-form-reset` event is no longer fired. Instead, you can listen to
-the `reset` event on either the native `form` or the `iron-form`.

--- a/iron-form.html
+++ b/iron-form.html
@@ -287,6 +287,9 @@ attach it to the `<iron-form>`:
             node.checked = defaults.checked;
           }
         }
+
+        // Causes `reset` event to be fired.
+        this._form.reset();
       },
 
       /**

--- a/iron-form.html
+++ b/iron-form.html
@@ -144,11 +144,17 @@ attach it to the `<iron-form>`:
        */
 
       /**
+       * Fired after the form is reset.
+       *
+       * @event iron-form-reset
+       */
+
+      /**
        * Fired after the form is submitted and a response is received. An
        * IronRequestElement is included as the event.detail object.
        *
        * @event iron-form-response
-      */
+       */
 
       /**
        * Fired after the form is submitted and an error is received. An
@@ -156,7 +162,7 @@ attach it to the `<iron-form>`:
        * IronRequestElement is included in event.detail.request.
        *
        * @event iron-form-error
-      */
+       */
 
       attached: function() {
         this._nodeObserver = Polymer.dom(this).observeNodes(
@@ -278,6 +284,8 @@ attach it to the `<iron-form>`:
         }
 
         // Ensure the native form fired the `reset` event.
+        // User might have bound `<button on-click="_resetIronForm">`, or directly called
+        // `ironForm.reset()`. In these cases we want to first reset the native form.
         if (!event || event.type !== 'reset' || event.target !== this._form) {
           this._form.reset();
           return;
@@ -293,6 +301,8 @@ attach it to the `<iron-form>`:
             node.checked = defaults.checked;
           }
         }
+
+        this.fire('iron-form-reset');
       },
 
       /**

--- a/iron-form.html
+++ b/iron-form.html
@@ -277,6 +277,12 @@ attach it to the `<iron-form>`:
           return;
         }
 
+        // Ensure the native form fired the `reset` event.
+        if (!event || event.type !== 'reset' || event.target !== this._form) {
+          this._form.reset();
+          return;
+        }
+
         // Load the initial values.
         var nodes = this._getSubmittableElements();
         for (var i = 0; i < nodes.length; i++) {
@@ -287,9 +293,6 @@ attach it to the `<iron-form>`:
             node.checked = defaults.checked;
           }
         }
-
-        // Causes `reset` event to be fired.
-        this._form.reset();
       },
 
       /**

--- a/test/basic.html
+++ b/test/basic.html
@@ -776,12 +776,68 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           var updated = form.serializeForm();
           expect(JSON.stringify(updated)).to.not.be.equal(initial);
-          form.addEventListener('reset', function() {
-            var final = form.serializeForm();
-            expect(JSON.stringify(initial)).to.be.equal(JSON.stringify(final));
-            done();
-          });
           form.reset();
+          var final = form.serializeForm();
+          expect(JSON.stringify(initial)).to.be.equal(JSON.stringify(final));
+          done();
+        });
+      });
+
+      test('fires reset and iron-form-reset events', function(done) {
+        var form = fixture('resetting');
+
+        // Wait one tick for observeNodes.
+        Polymer.Base.async(function() { 
+          var nativeResetSpy = sinon.stub();
+          var ironFormResetSpy = sinon.stub();
+          form.addEventListener('reset', nativeResetSpy);
+          form.addEventListener('iron-form-reset', ironFormResetSpy);
+
+          form.reset();
+          
+          expect(nativeResetSpy.callCount).to.be.equal(1);
+          expect(ironFormResetSpy.callCount).to.be.equal(1);
+          done();
+        });
+      });
+
+      test('handles <form> `reset` event', function(done) {
+        var form = fixture('resetting');
+
+        // Wait one tick for observeNodes.
+        Polymer.Base.async(function() {
+          var nativeResetSpy = sinon.stub();
+          var ironFormResetSpy = sinon.stub();
+          form.addEventListener('reset', nativeResetSpy);
+          form.addEventListener('iron-form-reset', ironFormResetSpy);
+
+          form.querySelector('[type=reset]').click();
+          
+          expect(nativeResetSpy.callCount).to.be.equal(1);
+          expect(ironFormResetSpy.callCount).to.be.equal(1);
+          done();
+        });
+      });
+
+      test('handles reset when triggered by other events', function(done) {
+        var form = fixture('resetting');
+
+        // Wait one tick for observeNodes.
+        Polymer.Base.async(function() {
+          var nativeResetSpy = sinon.stub();
+          var ironFormResetSpy = sinon.stub();
+          form.addEventListener('reset', nativeResetSpy);
+          form.addEventListener('iron-form-reset', ironFormResetSpy);
+
+          var input = document.getElementById('input1');
+          input.addEventListener('click', function(event) {
+            form.reset(event);
+          });
+          input.click();
+          
+          expect(nativeResetSpy.callCount).to.be.equal(1);
+          expect(ironFormResetSpy.callCount).to.be.equal(1);
+          done();
         });
       });
     });

--- a/test/basic.html
+++ b/test/basic.html
@@ -776,10 +776,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           var updated = form.serializeForm();
           expect(JSON.stringify(updated)).to.not.be.equal(initial);
+          form.addEventListener('reset', function() {
+            var final = form.serializeForm();
+            expect(JSON.stringify(initial)).to.be.equal(JSON.stringify(final));
+            done();
+          });
           form.reset();
-          var final = form.serializeForm();
-          expect(JSON.stringify(initial)).to.be.equal(JSON.stringify(final));
-          done();
         });
       });
     });


### PR DESCRIPTION
The native `reset` event is not invoked when calling `ironForm.reset()`. This PR ensures we call the `reset` method on the native form, which will trigger the `reset` event.
Reintroduce `iron-form-reset` for backward compatibility