### PR TITLE
Fix duplicate sumittable element in serialized form

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -423,6 +423,13 @@ attach it to the `<iron-form>`:
         for (var i = 0; i < nodes.length; i++) {
           var node = nodes[i];
 
+          // Since we traverse through slots and their distributed elements,
+          // we might have encountered this node already as light-dom element.
+          // Therefore, skip this node if we already processed it
+          if (submittable.indexOf(node) !== -1) {
+            continue;
+          }
+
           // An element is submittable if it is not disabled, and if it has a
           // name attribute.
           if (node.localName === 'slot' || node.localName === 'content') {

--- a/iron-form.html
+++ b/iron-form.html
@@ -416,52 +416,24 @@ attach it to the `<iron-form>`:
         return this._findElements(this._form, false);
       },
 
-      _findElements: function(parent, ignoreName) {
-        var node = parent.firstElementChild;
+      _findElements: function(parent, ignoreName, skipSlots) {
+        var selector = skipSlots ? ':not(slot):not(content)' : '*';
+        var nodes = Polymer.dom(parent).querySelectorAll(selector);
         var submittable = [];
 
-        // This algorithm is O(3n) in terms of nodes. It traverses depth-first
-        // downwards, but potentially skips subtrees if they have a shadowRoot.
-        // While this outer loop traverses down, at the end of this while loop
-        // we traverse up with another while-loop with stop-condition of our parent.
-        while (node) {
-          // If this note is not submittable itself, but it does have a shadowRoot,
-          // we have to traverse into the root, but not into its lightdom children.
-          // These lightdom children will be captured later in the slot assignedNodes
-          // in the shadowRoot
-          if (!isSubmittable(node, ignoreName) && node.root) {
-            Array.prototype.push.apply(submittable, this._findElements(node.root, ignoreName));
-          } else if (node.localName === 'slot' || node.localName === 'content') {
+        for (var i = 0; i < nodes.length; i++) {
+          var node = nodes[i];
+          // An element is submittable if it is not disabled, and if it has a
+          // name attribute.
+          if (node.localName === 'slot' || node.localName === 'content') {
             handleSubmittableInSlot(submittable, node, ignoreName);
-
-            // In this case we have to traverse down to the children,
-            // to see if we have more children in divs/submittables that we need
-            // to add and we know they are not in a projected shadowRoot
-          } else {
-            if (isSubmittable(node, ignoreName)) {
-              submittable.push(node);
-            }
-
-            // Check if we have children and if so traverse into it
-            if (node.firstElementChild) {
-              node = node.firstElementChild;
-              continue;
-            }
+          } else if (isSubmittable(node, ignoreName)) {
+            submittable.push(node);
+          } else if (node.root) {
+            Array.prototype.push.apply(submittable,
+              this._findElements(node.root, ignoreName, true /* skipSlots */));
           }
-
-          // At this point, we have no children, but maybe one of our parents has
-          // Therefore traverse up the parent tree and check if they have a sibling.
-          // Make sure not to traverse too far past our own parent.
-          while (node && !node.nextElementSibling) {
-            node = node.parentNode;
-
-            if (node === parent) {
-              return submittable;
-            }
-          }
-          node = node.nextElementSibling;
         }
-
         return submittable;
       },
 

--- a/iron-form.html
+++ b/iron-form.html
@@ -417,29 +417,51 @@ attach it to the `<iron-form>`:
       },
 
       _findElements: function(parent, ignoreName) {
-        var nodes = Polymer.dom(parent).querySelectorAll('*');
+        var node = parent.firstElementChild;
         var submittable = [];
 
-        for (var i = 0; i < nodes.length; i++) {
-          var node = nodes[i];
-
-          // Since we traverse through slots and their distributed elements,
-          // we might have encountered this node already as light-dom element.
-          // Therefore, skip this node if we already processed it
-          if (submittable.indexOf(node) !== -1) {
-            continue;
-          }
-
-          // An element is submittable if it is not disabled, and if it has a
-          // name attribute.
-          if (node.localName === 'slot' || node.localName === 'content') {
-            handleSubmittableInSlot(submittable, node, ignoreName);
-          } else if (isSubmittable(node, ignoreName)) {
-            submittable.push(node);
-          } else if (node.root) {
+        // This algorithm is O(3n) in terms of nodes. It traverses depth-first
+        // downwards, but potentially skips subtrees if they have a shadowRoot.
+        // While this outer loop traverses down, at the end of this while loop
+        // we traverse up with another while-loop with stop-condition of our parent.
+        while (node) {
+          // If this note is not submittable itself, but it does have a shadowRoot,
+          // we have to traverse into the root, but not into its lightdom children.
+          // These lightdom children will be captured later in the slot assignedNodes
+          // in the shadowRoot
+          if (!isSubmittable(node, ignoreName) && node.root) {
             Array.prototype.push.apply(submittable, this._findElements(node.root, ignoreName));
+          } else if (node.localName === 'slot' || node.localName === 'content') {
+            handleSubmittableInSlot(submittable, node, ignoreName);
+
+            // In this case we have to traverse down to the children,
+            // to see if we have more children in divs/submittables that we need
+            // to add and we know they are not in a projected shadowRoot
+          } else {
+            if (isSubmittable(node, ignoreName)) {
+              submittable.push(node);
+            }
+
+            // Check if we have children and if so traverse into it
+            if (node.firstElementChild) {
+              node = node.firstElementChild;
+              continue;
+            }
           }
+
+          // At this point, we have no children, but maybe one of our parents has
+          // Therefore traverse up the parent tree and check if they have a sibling.
+          // Make sure not to traverse too far past our own parent.
+          while (node && !node.nextElementSibling) {
+            node = node.parentNode;
+
+            if (node === parent) {
+              return submittable;
+            }
+          }
+          node = node.nextElementSibling;
         }
+
         return submittable;
       },
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -835,14 +835,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var form = fixture('resetting');
 
         // Wait one tick for observeNodes.
-        Polymer.Base.async(function() { 
+        Polymer.Base.async(function() {
           var nativeResetSpy = sinon.stub();
           var ironFormResetSpy = sinon.stub();
           form.addEventListener('reset', nativeResetSpy);
           form.addEventListener('iron-form-reset', ironFormResetSpy);
 
           form.reset();
-          
+
           expect(nativeResetSpy.callCount).to.be.equal(1);
           expect(ironFormResetSpy.callCount).to.be.equal(1);
           done();
@@ -860,7 +860,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           form.addEventListener('iron-form-reset', ironFormResetSpy);
 
           form.querySelector('[type=reset]').click();
-          
+
           expect(nativeResetSpy.callCount).to.be.equal(1);
           expect(ironFormResetSpy.callCount).to.be.equal(1);
           done();
@@ -882,7 +882,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             form.reset(event);
           });
           input.click();
-          
+
           expect(nativeResetSpy.callCount).to.be.equal(1);
           expect(ironFormResetSpy.callCount).to.be.equal(1);
           done();

--- a/test/slotted.html
+++ b/test/slotted.html
@@ -22,6 +22,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
+  <dom-module id="container-slot">
+    <template>
+      <slot></slot>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({is: 'container-slot'});
+    });
+    </script>
+  </dom-module>
+
   <dom-module id="slotted-form">
     <template>
       <iron-form id="form">
@@ -101,6 +112,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="nested-slotted-with-container">
+    <template>
+      <iron-form>
+        <form>
+          <container-slot>
+            <paper-checkbox name="papercheck" checked></paper-checkbox>
+          </container-slot>
+        </form>
+      </iron-form>
+    </template>
+  </test-fixture>
+
   <script>
     suite('slotted', function() {
       var form;
@@ -160,6 +183,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               server.respond();
             }, 1);
           });
+
+          suite('with a non-participating container', function() {
+            setup(function() {
+              form = fixture('nested-slotted-with-container');
+            });
+            test('does not serialize components twice', function(done) {
+              // Wait one tick for observeNodes.
+              Polymer.Base.async(function() {
+                var serialized = form.serializeForm();
+                expect(form.serializeForm()).to.deep.equal({papercheck: 'on'});
+                done();
+              }, 1);
+            });
+          })
         });
       });
 


### PR DESCRIPTION
Not really happy with this fix, but I was not able to figure out how to make this work. The reason this went wrong is because all content in slots is flattened before being processed by `<iron-form>`. This means that if you have any element directly in the `<form>`, it will also show up in the flattened slots list. Therefore, before insertion in the regular array, check if it is already in there. This is computationally not ideal, but I was not able to figure out how not to traverse twice, as we do not know how the nodes end up in the flattened slots list. I am also not 100% certain we catch all cases now :cry: 

Fixes #235 