### PR TITLE
Collect only elements that implement validate() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ around a native `<form>`
 - related, since elements are now distributed to the `iron-form`, they no longer
 need to implement `IronFormElementBehavior` to register for submission. However
 they are required to have a `name` and a `value` attribute (which the behaviour
-  also added), and if you want to validate them, they _must_ implement a `validate()`
-  method.
+also added), and to optionally implement the `validate()` method to control
+validation of their shadowRoot validatable elements.
 - the `serialize` method has been renamed to `serializeForm` (because Polymer 2.0
-  is already using a `serialize` method, and we can't stomp over it)
+  is already using a `serialize` method, and we can't stomp over it).
 - in `iron-form` 2.x, the `reset` and `submit` methods now accept an `event` as
 input, which will be prevented if it exists.
 - the `disableNativeValidationUi` property has been removed: because `iron-form`

--- a/iron-form.html
+++ b/iron-form.html
@@ -98,8 +98,8 @@ attach it to the `<iron-form>`:
   (function() {
     function isSubmittable(node, ignoreName) {
       // An element is submittable if it is not disabled, and if it has a
-      // 'name' attribute
-      return  (!node.disabled && (ignoreName || node.name));
+      // 'name' attribute. If we ignore the name, check if is validatable.
+      return  (!node.disabled && (ignoreName ? typeof node.validate === 'function' : node.name));
     }
 
     /**

--- a/iron-form.html
+++ b/iron-form.html
@@ -99,6 +99,9 @@ attach it to the `<iron-form>`:
     function isSubmittable(node, ignoreName) {
       // An element is submittable if it is not disabled, and if it has a
       // 'name' attribute. If we ignore the name, check if is validatable.
+      // This allows `_findElements` to decide if to explore an element's shadowRoot or not:
+      // an element implementing `validate()` is considered validatable, and we don't
+      // search for validatables in its shadowRoot.
       return  (!node.disabled && (ignoreName ? typeof node.validate === 'function' : node.name));
     }
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -30,6 +30,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </dom-module>
 
+  <dom-module id="paper-input-wrapper">
+    <template>
+      <paper-input required/>
+    </template>
+  </dom-module>
+
   <test-fixture id="serialization">
     <template>
       <div>
@@ -184,6 +190,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <paper-input pattern="aa" value="b"></paper-input>
           </form>
         </iron-form>
+
+        <iron-form id="custom-invalid-no-validate">
+          <form action="/get" method="get">
+            <paper-input-wrapper></paper-input-wrapper>
+          </form>
+        </iron-form>
       </div>
     </template>
   </test-fixture>
@@ -253,6 +265,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suiteSetup(function () {
         Polymer({is: 'x-input-wrapper'});
+        Polymer({is: 'paper-input-wrapper'});
       });
 
       setup(function() {
@@ -536,6 +549,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Wait one tick for observeNodes.
         Polymer.Base.async(function() {
           form.validate();
+          expect(form.validate()).to.be.equal(false);
+          form.submit();
+          server.respond();
+        });
+
+        setTimeout(function() {
+          expect(responses).to.be.equal(0);
+          done();
+        },  200);
+      });
+
+      test('<paper-input-wrapper> not implementing validate() is validated and does not submit the form', function(done) {
+        var form = f.querySelector('#custom-invalid-no-validate');
+
+        var responses = 0;
+        form.addEventListener('iron-form-response', function(event) {
+          responses++;
+        });
+
+        // Wait one tick for observeNodes.
+        Polymer.Base.async(function() {
           expect(form.validate()).to.be.equal(false);
           form.submit();
           server.respond();


### PR DESCRIPTION
Fixes #242 by ensuring that we collect only element that are either submittable (have a `name`) or validatable (implement `validate()`)