### PR TITLE
search <form> sooner

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -207,18 +207,29 @@ attach it to the `<iron-form>`:
        * @return {void}
        */
       attached: function() {
+        // We've already found the `<form>`, return.
         if (this._form) {
           return;
         }
+        // Search for the `<form>`, if we don't find it, observe for
+        // mutations.
         this._form = Polymer.dom(this).querySelector('form');
         if (this._form) {
           this._init();
+          // Since some elements might not be upgraded yet at this time,
+          // we won't be able to look into their shadowRoots for submittables.
+          // We wait a tick and check again for any missing submittable default
+          // values.
+          this.async(this._saveInitialValues.bind(this));
         } else {
           this._nodeObserver = Polymer.dom(this).observeNodes(
             function(mutations) {
               for (var i = 0; i < mutations.addedNodes.length; i++) {
                 if (mutations.addedNodes[i].tagName === 'FORM') {
                   this._form = mutations.addedNodes[i];
+                  // At this point in time, all custom elements are expected
+                  // to be upgraded, hence we'll be able to traverse their
+                  // shadowRoots.
                   this._init();
                   Polymer.dom(this).unobserveNodes(this._nodeObserver);
                   this._nodeObserver = null;
@@ -244,6 +255,10 @@ attach it to the `<iron-form>`:
 
         // Save the initial values.
         this._defaults = this._defaults || new WeakMap();
+        this._saveInitialValues();
+      },
+
+      _saveInitialValues: function() {
         var nodes = this._getSubmittableElements();
         for (var i = 0; i < nodes.length; i++) {
           var node = nodes[i];

--- a/iron-form.html
+++ b/iron-form.html
@@ -207,16 +207,25 @@ attach it to the `<iron-form>`:
        * @return {void}
        */
       attached: function() {
-        this._nodeObserver = Polymer.dom(this).observeNodes(
-          function(mutations) {
-            for (var i = 0; i < mutations.addedNodes.length; i++) {
-              if (mutations.addedNodes[i].tagName === 'FORM' && !this._alreadyCalledInit) {
-                this._alreadyCalledInit = true;
-                this._form = mutations.addedNodes[i];
-                this._init();
+        if (this._form) {
+          return;
+        }
+        this._form = Polymer.dom(this).querySelector('form');
+        if (this._form) {
+          this._init();
+        } else {
+          this._nodeObserver = Polymer.dom(this).observeNodes(
+            function(mutations) {
+              for (var i = 0; i < mutations.addedNodes.length; i++) {
+                if (mutations.addedNodes[i].tagName === 'FORM') {
+                  this._form = mutations.addedNodes[i];
+                  this._init();
+                  Polymer.dom(this).unobserveNodes(this._nodeObserver);
+                  this._nodeObserver = null;
+                }
               }
-            }
-          }.bind(this));
+            }.bind(this));
+        }
       },
 
       /**

--- a/iron-form.html
+++ b/iron-form.html
@@ -207,7 +207,8 @@ attach it to the `<iron-form>`:
        * @return {void}
        */
       attached: function() {
-        // We've already found the `<form>`, return.
+        // We might have been detached then re-attached.
+        // Avoid searching again for the <form> if we already found it.
         if (this._form) {
           return;
         }


### PR DESCRIPTION
Search for the `<form>` immediately on attached. If it's not there, use the mutation observer.

In `_init()`, we also save the initial default values of submittable children. Since in order to be submittable, an element needs to have the `name` attribute, we don't need to wait for it to be upgraded (in case it is a custom element).

This helps writing tests without requiring to wait for the mutation observer timing.
It's particularly handy for custom element authors using `iron-form` in their element shadowRoot, e.g. a `<update-info-form>` element containing an `<iron-form>` in its shadowRoot: the user of `<update-info-form>` will have to wait for the mutation observer timing as well.