### PR TITLE
Query whole subtree

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -125,13 +125,12 @@ attach it to the `<iron-form>`:
         // getDistributedNodes flattens the tree.
         if (isSubmittable(assignedNodes[i], ignoreName)) {
           submittable.push(assignedNodes[i]);
-        }
-
-        var nestedAssignedNodes = Polymer.dom(assignedNodes[i]).queryDistributedElements('*');
-
-        for (var j = 0; j < nestedAssignedNodes.length; j++) {
-          if (isSubmittable(nestedAssignedNodes[j], ignoreName)) {
-            submittable.push(nestedAssignedNodes[j]);
+        } else {
+          var nestedAssignedNodes = Polymer.dom(assignedNodes[i]).querySelectorAll('*');
+          for (var j = 0; j < nestedAssignedNodes.length; j++) {
+            if (isSubmittable(nestedAssignedNodes[j], ignoreName)) {
+              submittable.push(nestedAssignedNodes[j]);
+            }
           }
         }
       }

--- a/iron-form.html
+++ b/iron-form.html
@@ -96,45 +96,6 @@ attach it to the `<iron-form>`:
 
   <script>
   (function() {
-    function isSubmittable(node, ignoreName) {
-      // An element is submittable if it is not disabled, and if it has a
-      // 'name' attribute. If we ignore the name, check if is validatable.
-      // This allows `_findElements` to decide if to explore an element's shadowRoot or not:
-      // an element implementing `validate()` is considered validatable, and we don't
-      // search for validatables in its shadowRoot.
-      return  (!node.disabled && (ignoreName ? typeof node.validate === 'function' : node.name));
-    }
-
-    /**
-     * Traverse the distributed nodes of a slot or content element
-     * and add all submittable nodes to `submittable`.
-     * @param  {Array<Node>} submittable Reference to the arrray of submittables
-     * @param  {Node} node        The slot or content node
-     * @param  {boolean} ignoreName  Whether the name of the submittable nodes should be disregarded
-     * @return {void}
-     */
-    function handleSubmittableInSlot(submittable, node, ignoreName) {
-      var assignedNodes = Polymer.dom(node).getDistributedNodes();
-
-      for (var i = 0; i < assignedNodes.length; i++) {
-        if (assignedNodes[i].nodeType === Node.TEXT_NODE) {
-          continue;
-        }
-
-        // Note: assignedNodes does not contain <slot> or <content> because 
-        // getDistributedNodes flattens the tree.
-        if (isSubmittable(assignedNodes[i], ignoreName)) {
-          submittable.push(assignedNodes[i]);
-        } else {
-          var nestedAssignedNodes = Polymer.dom(assignedNodes[i]).querySelectorAll('*');
-          for (var j = 0; j < nestedAssignedNodes.length; j++) {
-            if (isSubmittable(nestedAssignedNodes[j], ignoreName)) {
-              submittable.push(nestedAssignedNodes[j]);
-            }
-          }
-        }
-      }
-    }
 
     Polymer({
       is: 'iron-form',
@@ -466,25 +427,88 @@ attach it to the `<iron-form>`:
         return this._findElements(this._form, false /* ignoreName */, false /* skipSlots */);
       },
 
-      _findElements: function(parent, ignoreName, skipSlots) {
-        var selector = skipSlots ? ':not(slot):not(content)' : '*';
-        var nodes = Polymer.dom(parent).querySelectorAll(selector);
-        var submittable = [];
-
+      /**
+       * Traverse the parent element to find and add all submittable nodes to `submittable`.
+       * @param  {!Node} parent The parent node
+       * @param  {!boolean} ignoreName  Whether the name of the submittable nodes should be disregarded
+       * @param  {!boolean} skipSlots  Whether to skip traversing of slot elements
+       * @param  {!Array<!Node>=} submittable Reference to the array of submittables
+       * @return {!Array<!Node>}
+       * @private
+       */
+      _findElements: function(parent, ignoreName, skipSlots, submittable) {
+        submittable = submittable || [];
+        var nodes = Polymer.dom(parent).querySelectorAll('*');
         for (var i = 0; i < nodes.length; i++) {
-          var node = nodes[i];
           // An element is submittable if it is not disabled, and if it has a
           // name attribute.
-          if (node.localName === 'slot' || node.localName === 'content') {
-            handleSubmittableInSlot(submittable, node, ignoreName);
-          } else if (isSubmittable(node, ignoreName)) {
-            submittable.push(node);
-          } else if (node.root) {
-            Array.prototype.push.apply(submittable,
-              this._findElements(node.root, ignoreName, true /* skipSlots */));
+          if (!skipSlots &&
+              (nodes[i].localName === 'slot' || nodes[i].localName === 'content')) {
+            this._searchSubmittableInSlot(submittable, nodes[i], ignoreName);
+          } else {
+            this._searchSubmittable(submittable, nodes[i], ignoreName);
           }
         }
         return submittable;
+      },
+
+      /**
+       * Traverse the distributed nodes of a slot or content element
+       * and add all submittable nodes to `submittable`.
+       * @param  {!Array<!Node>} submittable Reference to the array of submittables
+       * @param  {!Node} node The slot or content node
+       * @param  {!boolean} ignoreName  Whether the name of the submittable nodes should be disregarded
+       * @return {void}
+       * @private
+       */
+      _searchSubmittableInSlot: function(submittable, node, ignoreName) {
+        var assignedNodes = Polymer.dom(node).getDistributedNodes();
+
+        for (var i = 0; i < assignedNodes.length; i++) {
+          if (assignedNodes[i].nodeType === Node.TEXT_NODE) {
+            continue;
+          }
+
+          // Note: assignedNodes does not contain <slot> or <content> because 
+          // getDistributedNodes flattens the tree.
+          this._searchSubmittable(submittable, assignedNodes[i], ignoreName);
+          var nestedAssignedNodes = Polymer.dom(assignedNodes[i]).querySelectorAll('*');
+          for (var j = 0; j < nestedAssignedNodes.length; j++) {
+            this._searchSubmittable(submittable, nestedAssignedNodes[j], ignoreName);
+          }
+        }
+      },
+
+      /**
+       * Traverse the distributed nodes of a slot or content element
+       * and add all submittable nodes to `submittable`.
+       * @param  {!Array<!Node>} submittable Reference to the array of submittables
+       * @param  {!Node} node The node to be
+       * @param  {!boolean} ignoreName  Whether the name of the submittable nodes should be disregarded
+       * @return {void}
+       * @private
+       */
+      _searchSubmittable: function(submittable, node, ignoreName) {
+        if (this._isSubmittable(node, ignoreName)) {
+          submittable.push(node);
+        } else if (node.root) {
+          this._findElements(node.root, ignoreName, true /* skipSlots */, submittable);
+        }
+      },
+
+      /**
+       * An element is submittable if it is not disabled, and if it has a
+       * 'name' attribute. If we ignore the name, check if is validatable.
+       * This allows `_findElements` to decide if to explore an element's shadowRoot or not:
+       * an element implementing `validate()` is considered validatable, and we don't
+       * search for validatables in its shadowRoot.
+       * @param {!Node} node
+       * @param {!boolean} ignoreName
+       * @return {boolean}
+       * @private
+       */
+      _isSubmittable: function(node, ignoreName) {
+        return  (!node.disabled && (ignoreName ? typeof node.validate === 'function' : node.name));
       },
 
       _serializeElementValues: function(element) {

--- a/test/slotted.html
+++ b/test/slotted.html
@@ -68,7 +68,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <slotted-form>
         <div>
           <paper-checkbox name="checkbox" checked></paper-checkbox>
-          <input name="input" value="some" />
+          <div>
+            <input name="input" value="some" />
+          </div>
         </div>
       </slotted-form>
     </template>

--- a/test/slotted.html
+++ b/test/slotted.html
@@ -22,6 +22,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
+  <dom-module id="x-input-wrapper">
+    <template>
+      <input name="check_wrapped" value="foo"/>
+    </template>
+    <script>
+      HTMLImports.whenReady(function() {
+        Polymer({is: 'x-input-wrapper'});
+      });
+      </script>
+  </dom-module>
+
   <dom-module id="container-slot">
     <template>
       <slot></slot>
@@ -72,6 +83,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <input name="input" value="some" />
           </div>
         </div>
+        <x-input-wrapper></x-input-wrapper>
       </slotted-form>
     </template>
   </test-fixture>
@@ -154,7 +166,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
         test('serializes both normal and distributed nodes', function(done) {
           form.addEventListener('iron-form-response', function(event) {
-            var expectedUrl = encodeURI('/get?original=works&checkbox=on&input=some');
+            var expectedUrl = encodeURI('/get?original=works&checkbox=on&input=some&check_wrapped=foo');
             expect(event.detail.url).to.equal(expectedUrl);
             expect(event.detail.response.success).to.be.equal(true);
             done();


### PR DESCRIPTION
Fixes #249 
Made the search for submittable coherent when done in distributed content or slotted content.
- if the node is validatable/submittable, we collect it, otherwise we look into its shadowRoot
- slots need a special handling, as distributed nodes will only be the top nodes, hence we cannot querySelectorAll in the slot, but we have to do 2 loops - 1 to get the topmost child nodes, and 1 to query their content.