### PR TITLE
Fix submit() example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components*
 bower-*.json
 node_modules
+analysis.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 bower_components*
 bower-*.json
 node_modules
-analysis.json

--- a/iron-form.d.ts
+++ b/iron-form.d.ts
@@ -34,12 +34,21 @@
  * want to submit it from a custom element's click handler, you need to explicitly
  * call the `iron-form`'s `submit` method.
  *
- *   Example:
+ *   Example (using `<paper-button>` for the form `<iron-form id="myForm">`):
  *
- *     <paper-button raised onclick="submitForm()">Submit</paper-button>
+    <paper-button raised on-tap="submitForm">Submit</paper-button>
  *
  *     function submitForm() {
- *       document.getElementById('iron-form').submit();
+ *       this.$.myForm.submit();
+ *     }
+ *
+ *   or (using `<button>` for the same form):
+ *
+ *     <button raised onclick="submitForm()">Submit</button>
+ *
+ *     function submitForm() {
+ *       // `this.$.myForm.submit();`  or
+ *       document.getElementById('myForm').submit();
  *     }
  *
  * If you are not using the `allow-redirect` mode, then you also have the option of

--- a/iron-form.d.ts
+++ b/iron-form.d.ts
@@ -36,7 +36,7 @@
  *
  *   Example (using `<paper-button>` for the form `<iron-form id="myForm">`):
  *
-    <paper-button raised on-click="submitForm">Submit</paper-button>
+ *     <paper-button raised on-click="submitForm">Submit</paper-button>
  *
  *     function submitForm() {
  *       this.$.myForm.submit();

--- a/iron-form.d.ts
+++ b/iron-form.d.ts
@@ -42,12 +42,11 @@
  *       this.$.myForm.submit();
  *     }
  *
- *   or (using `<button>` for the same form):
+ *   or (using `<button>` for a form in the same document):
  *
  *     <button raised onclick="submitForm()">Submit</button>
  *
  *     function submitForm() {
- *       // `this.$.myForm.submit();`  or
  *       document.getElementById('myForm').submit();
  *     }
  *

--- a/iron-form.d.ts
+++ b/iron-form.d.ts
@@ -36,7 +36,7 @@
  *
  *   Example (using `<paper-button>` for the form `<iron-form id="myForm">`):
  *
-    <paper-button raised on-tap="submitForm">Submit</paper-button>
+    <paper-button raised on-click="submitForm">Submit</paper-button>
  *
  *     function submitForm() {
  *       this.$.myForm.submit();

--- a/iron-form.html
+++ b/iron-form.html
@@ -36,7 +36,7 @@ call the `iron-form`'s `submit` method.
 
   Example (using `<paper-button>` for the form `<iron-form id="myForm">`):
 
-    <paper-button raised on-tap="submitForm">Submit</paper-button>
+    <paper-button raised on-click="submitForm">Submit</paper-button>
 
     function submitForm() {
       this.$.myForm.submit();

--- a/iron-form.html
+++ b/iron-form.html
@@ -42,12 +42,11 @@ call the `iron-form`'s `submit` method.
       this.$.myForm.submit();
     }
 
-  or (using `<button>` for the same form):
+  or (using `<button>` for a form in the same document):
 
     <button raised onclick="submitForm()">Submit</button>
 
     function submitForm() {
-      // `this.$.myForm.submit();`  or
       document.getElementById('myForm').submit();
     }
 

--- a/iron-form.html
+++ b/iron-form.html
@@ -34,12 +34,21 @@ By default, a native `<button>` element will submit this form. However, if you
 want to submit it from a custom element's click handler, you need to explicitly
 call the `iron-form`'s `submit` method.
 
-  Example:
+  Example (using `<paper-button>` for the form `<iron-form id="myForm">`):
 
-    <paper-button raised onclick="submitForm()">Submit</paper-button>
+    <paper-button raised on-tap="submitForm">Submit</paper-button>
 
     function submitForm() {
-      document.getElementById('iron-form').submit();
+      this.$.myForm.submit();
+    }
+
+  or (using `<button>` for the same form):
+
+    <button raised onclick="submitForm()">Submit</button>
+
+    function submitForm() {
+      // `this.$.myForm.submit();`  or
+      document.getElementById('myForm').submit();
     }
 
 If you are not using the `allow-redirect` mode, then you also have the option of
@@ -235,7 +244,7 @@ attach it to the `<iron-form>`:
             if ('checked' in node) {
               defaults.checked = node.checked;
             }
-            // In 1.x iron-form would reset `invalid`, so 
+            // In 1.x iron-form would reset `invalid`, so
             // keep it here for backwards compat.
             if ('invalid' in node) {
               defaults.invalid = node.invalid;


### PR DESCRIPTION
The example for `submit()` does not work: `paper-button` should use `on-tap="submitForm">` vs `onclick="submitForm()">`, and `iron-form` is not recognized by `document.getElementById('myForm')` but by `this.$.myForm`. On the other hand, a standard `button` element uses `onclick="submitForm()">`, and its action can use either `document.getElementById('myForm')` or `this.$.myForm`. This correction shows examples for both.

See [this pen](https://codepen.io/johnthad/pen/mxyzBM?editors=1001) for a demonstration.