### PR TITLE
make value of dynamic elements resettable

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -184,7 +184,7 @@ attach it to the `<iron-form>`:
           // we won't be able to look into their shadowRoots for submittables.
           // We wait a tick and check again for any missing submittable default
           // values.
-          this.async(this._saveInitialValues.bind(this));
+          this.async(this._saveInitialValues.bind(this), 1);
         } else {
           this._nodeObserver = Polymer.dom(this).observeNodes(
             function(mutations) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -233,11 +233,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-  <test-fixture id="reset-dynamic">
+  <test-fixture id="reset-dynamic-polymer1">
     <template>
       <iron-form>
         <form action="/get" method="get">
+          <template id="repeat" is="dom-repeat" >
+              <paper-input name="paper_[[index]]" id="paper_[[index]]" value="input"></paper-input>
+          </template>
+        </form>
+      </iron-form>
+    </template>
+  </test-fixture>
 
+  <test-fixture id="reset-dynamic-polymer2">
+    <template>
+      <iron-form>
+        <form action="/get" method="get">
           <dom-repeat id="repeat">
             <template>
                 <paper-input name="paper_[[index]]" id="paper_[[index]]" value="input"></paper-input>
@@ -882,11 +893,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       })
 
       test('reset dynamic element', function(done) {
-        var form = fixture('reset-dynamic');
+        var form;
+
+        if (Polymer.Element) {
+          form = fixture('reset-dynamic-polymer2');
+        } else {
+          form = fixture('reset-dynamic-polymer1');
+        }
 
         document.getElementById('repeat').items = ['item'];
-       
+
         Polymer.Base.async(function() {
+
           document.getElementById('paper_0').value = 'input1++';
 
           form.reset();

--- a/test/basic.html
+++ b/test/basic.html
@@ -233,6 +233,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="reset-dynamic">
+    <template>
+      <iron-form>
+        <form action="/get" method="get">
+
+          <dom-repeat id="repeat">
+            <template>
+                <paper-input name="paper_[[index]]" id="paper_[[index]]" value="input"></paper-input>
+            </template>
+          </dom-repeat>
+        </form>
+      </iron-form>
+    </template>
+  </test-fixture>
+
   <test-fixture id="content-type">
     <template>
       <div>
@@ -864,6 +879,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(JSON.stringify(initial)).to.be.equal(JSON.stringify(final));
           done();
         });
+      })
+
+      test('reset dynamic element', function(done) {
+        var form = fixture('reset-dynamic');
+
+        document.getElementById('repeat').items = ['item'];
+       
+        Polymer.Base.async(function() {
+          document.getElementById('paper_0').value = 'input1++';
+
+          form.reset();
+          
+          expect(document.getElementById('paper_0').value).to.be.equal('input');
+          done();
+        }, 1);
       });
 
       test('fires reset and iron-form-reset events', function(done) {


### PR DESCRIPTION
call _saveInitialValues after render. This ensures that dynmic input elements such as those inside  a grid element are correctly discovered and can be reset.

fixes #261