### PR TITLE
Fixing reset method

### DIFF
--- a/iron-form.html
+++ b/iron-form.html
@@ -261,7 +261,7 @@ attach it to the `<iron-form>`:
               defaults.invalid = node.invalid;
             }
             // This if helps us to reset the iron-inputs in
-            // the form when the reset method is called
+            // the form when the reset method is called.
             if ('bindValue' in node) {
               defaults.bindValue = node.bindValue;
             }

--- a/iron-form.html
+++ b/iron-form.html
@@ -260,7 +260,7 @@ attach it to the `<iron-form>`:
             if ('invalid' in node) {
               defaults.invalid = node.invalid;
             }
-            // This if helps us to reset the iron-inputs in
+            // This if helps resets the iron-inputs in
             // the form when the reset method is called.
             if ('bindValue' in node) {
               defaults.bindValue = node.bindValue;

--- a/iron-form.html
+++ b/iron-form.html
@@ -260,6 +260,11 @@ attach it to the `<iron-form>`:
             if ('invalid' in node) {
               defaults.invalid = node.invalid;
             }
+            // This if helps us to reset the iron-inputs in
+            // the form when the reset method is called
+            if ('bindValue' in node) {
+              defaults.bindValue = node.bindValue;
+            }
             this._defaults.set(node, defaults);
           }
         }


### PR DESCRIPTION
The `iron-input` elements inside the `iron-form` don't clear their value when the reset method is called.

## Expected outcome

The `iron-input` elements should reset their value when the reset method of the `iron-form` is called.

## Actual outcome

The `iron-input` elements keep their value when the reset method of the `iron-form` is called.

## Steps to reproduce

1. Put an `iron-form` element on the page.
2. Put a `iron-input` element inside the `iron-form` element.
3. Type a value in the `iron-input` element
4. Call the reset method of the `iron-form`