### PR TITLE
Resolve issue with slots being marked as valid submittable elements

### DIFF
--- a/iron-form.js
+++ b/iron-form.js
@@ -475,8 +475,12 @@ Polymer({
     for (var i = 0; i < nodes.length; i++) {
       // An element is submittable if it is not disabled, and if it has a
       // name attribute.
-      if (!skipSlots &&
-          (nodes[i].localName === 'slot' || nodes[i].localName === 'content')) {
+      var isSlot = nodes[i].localName === 'slot' || nodes[i].localName === 'content';
+      if (skipSlots && isSlot) {
+        continue;
+      }
+
+      if (isSlot) {
         this._searchSubmittableInSlot(submittable, nodes[i], ignoreName);
       } else {
         this._searchSubmittable(submittable, nodes[i], ignoreName);


### PR DESCRIPTION
There seems to be an issue where slots inside a shadow root will be marked as valid submittable elements. This PR hopes to resolve that issue.